### PR TITLE
Allow function declarations using `_cb` types.

### DIFF
--- a/src/Tokstyle/Cimple/Parser.y
+++ b/src/Tokstyle/Cimple/Parser.y
@@ -487,8 +487,12 @@ LeafType
 
 FunctionDecl :: { () }
 FunctionDecl
-:	FunctionPrototype(ID_VAR) FunctionBody				{ () }
-|	static FunctionPrototype(ID_VAR) FunctionBody			{ () }
+:	FunctionDeclarator						{ () }
+|	static FunctionDeclarator					{ () }
+
+FunctionDeclarator
+:	QualType ID_VAR ';'						{ () }
+|	FunctionPrototype(ID_VAR) FunctionBody				{ () }
 
 FunctionPrototype(id)
 :	QualType id FunctionParamList					{ () }


### PR DESCRIPTION
E.g. `foo_cb myfunc`, meaning the same as `void myfunc(int a)` if there
was a `typedef void foo_cb(int a)` before it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/24)
<!-- Reviewable:end -->
