### PR TITLE
Add `crypto_sign` to the list of known constant prefixes.

### DIFF
--- a/src/Tokstyle/Cimple/Lexer.x
+++ b/src/Tokstyle/Cimple/Lexer.x
@@ -66,6 +66,7 @@ tokens :-
 <0,ppSC>	"crypto_box_"[A-Z][A-Z0-9_]*		{ mkL IdConst }
 <0,ppSC>	"crypto_hash_sha256_"[A-Z][A-Z0-9_]*	{ mkL IdConst }
 <0,ppSC>	"crypto_hash_sha512_"[A-Z][A-Z0-9_]*	{ mkL IdConst }
+<0,ppSC>	"crypto_sign_"[A-Z][A-Z0-9_]*		{ mkL IdConst }
 <0,ppSC>	"MAX"					{ mkL IdConst }
 <0,ppSC>	"MIN"					{ mkL IdConst }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/27)
<!-- Reviewable:end -->
