### PR TITLE
Add `crypto_auth` to the list of known constant prefixes.

### DIFF
--- a/src/Tokstyle/Cimple/Lexer.x
+++ b/src/Tokstyle/Cimple/Lexer.x
@@ -63,6 +63,7 @@ tokens :-
 <0,ppSC>	"timeval"				{ mkL IdSueType }
 
 -- Sodium constants.
+<0,ppSC>	"crypto_auth_"[A-Z][A-Z0-9_]*		{ mkL IdConst }
 <0,ppSC>	"crypto_box_"[A-Z][A-Z0-9_]*		{ mkL IdConst }
 <0,ppSC>	"crypto_hash_sha256_"[A-Z][A-Z0-9_]*	{ mkL IdConst }
 <0,ppSC>	"crypto_hash_sha512_"[A-Z][A-Z0-9_]*	{ mkL IdConst }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/34)
<!-- Reviewable:end -->
