### PR TITLE
Remove warning flags. These are now default.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,10 +18,6 @@ haskell_library(
         "src/Tokstyle/Cimple/Lexer.hs",
         "src/Tokstyle/Cimple/Tokens.hs",
     ],
-    compiler_flags = [
-        "-Wall",
-        "-Werror",
-    ],
     src_strip_prefix = "src",
     version = "0.0.2",
     visibility = ["//hs-tokstyle:__subpackages__"],
@@ -44,11 +40,7 @@ haskell_library(
         "src/Tokstyle/Cimple/AST.hs",
         "src/Tokstyle/Cimple/Parser.hs",
     ],
-    compiler_flags = [
-        "-Wall",
-        "-Werror",
-        "-Wno-unused-imports",
-    ],
+    compiler_flags = ["-Wno-unused-imports"],
     src_strip_prefix = "src",
     version = "0.0.2",
     visibility = ["//hs-tokstyle:__subpackages__"],
@@ -68,10 +60,6 @@ haskell_library(
             "src/Tokstyle/Cimple/Tokens.hs",
         ],
     ),
-    compiler_flags = [
-        "-Wall",
-        "-Werror",
-    ],
     src_strip_prefix = "src",
     version = "0.0.2",
     visibility = ["//visibility:public"],
@@ -93,10 +81,6 @@ haskell_library(
 
 hspec_test(
     name = "test",
-    compiler_flags = [
-        "-Wall",
-        "-Werror",
-    ],
     deps = [
         ":cimple-lexer",
         ":cimple-parser",

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -4,10 +4,6 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_binary")
 haskell_binary(
     name = "check-c",
     srcs = ["check-c.hs"],
-    compiler_flags = [
-        "-Wall",
-        "-Werror",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         "//hs-tokstyle",
@@ -18,10 +14,6 @@ haskell_binary(
 haskell_binary(
     name = "check-cimple",
     srcs = ["check-cimple.hs"],
-    compiler_flags = [
-        "-Wall",
-        "-Werror",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         "//hs-tokstyle",
@@ -33,10 +25,6 @@ haskell_binary(
 haskell_binary(
     name = "dump-tokens",
     srcs = ["dump-tokens.hs"],
-    compiler_flags = [
-        "-Wall",
-        "-Werror",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         "//hs-tokstyle:cimple-lexer",


### PR DESCRIPTION
toktok-stack sets default -Wall -Werror.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/47)
<!-- Reviewable:end -->
