### PR TITLE
Remove cimple-lexer and cimple-parser targets.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -22,6 +22,7 @@ haskell_library(
     version = "0.0.2",
     visibility = ["//hs-tokstyle:__subpackages__"],
     deps = [
+        hazel_library("aeson"),
         hazel_library("array"),
         hazel_library("base"),
         hazel_library("text"),
@@ -46,6 +47,7 @@ haskell_library(
     visibility = ["//hs-tokstyle:__subpackages__"],
     deps = [
         ":cimple-lexer",
+        hazel_library("aeson"),
         hazel_library("array"),
         hazel_library("base"),
     ],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,23 +12,6 @@ alex_lexer(
     src = "src/Tokstyle/Cimple/Lexer.x",
 )
 
-haskell_library(
-    name = "cimple-lexer",
-    srcs = [
-        "src/Tokstyle/Cimple/Lexer.hs",
-        "src/Tokstyle/Cimple/Tokens.hs",
-    ],
-    src_strip_prefix = "src",
-    version = "0.0.2",
-    visibility = ["//hs-tokstyle:__subpackages__"],
-    deps = [
-        hazel_library("aeson"),
-        hazel_library("array"),
-        hazel_library("base"),
-        hazel_library("text"),
-    ],
-)
-
 happy_parser(
     name = "Parser",
     src = "src/Tokstyle/Cimple/Parser.y",
@@ -36,38 +19,17 @@ happy_parser(
 )
 
 haskell_library(
-    name = "cimple-parser",
-    srcs = [
-        "src/Tokstyle/Cimple/AST.hs",
+    name = "hs-tokstyle",
+    srcs = glob(["src/**/*.*hs"]) + [
+        "src/Tokstyle/Cimple/Lexer.hs",
         "src/Tokstyle/Cimple/Parser.hs",
     ],
-    compiler_flags = ["-Wno-unused-imports"],
-    src_strip_prefix = "src",
-    version = "0.0.2",
-    visibility = ["//hs-tokstyle:__subpackages__"],
-    deps = [
-        ":cimple-lexer",
-        hazel_library("aeson"),
-        hazel_library("array"),
-        hazel_library("base"),
-    ],
-)
-
-haskell_library(
-    name = "hs-tokstyle",
-    srcs = glob(
-        ["src/**/*.*hs"],
-        exclude = [
-            "src/Tokstyle/Cimple/AST.hs",
-            "src/Tokstyle/Cimple/Tokens.hs",
-        ],
-    ),
     src_strip_prefix = "src",
     version = "0.0.2",
     visibility = ["//visibility:public"],
     deps = [
-        ":cimple-lexer",
-        ":cimple-parser",
+        hazel_library("aeson"),
+        hazel_library("array"),
         hazel_library("base"),
         hazel_library("bytestring"),
         hazel_library("compact"),
@@ -82,10 +44,9 @@ haskell_library(
 )
 
 hspec_test(
-    name = "test",
+    name = "testsuite",
+    size = "small",
     deps = [
-        ":cimple-lexer",
-        ":cimple-parser",
         ":hs-tokstyle",
         hazel_library("base"),
         hazel_library("hspec"),

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: webservice $PORT

--- a/src/Tokstyle/Cimple/AST.hs
+++ b/src/Tokstyle/Cimple/AST.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveFunctor     #-}
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE DeriveTraversable #-}
 module Tokstyle.Cimple.AST
     ( AssignOp (..)
@@ -8,6 +9,9 @@ module Tokstyle.Cimple.AST
     , Node (..)
     , Scope (..)
     ) where
+
+import           Data.Aeson   (FromJSON, ToJSON)
+import           GHC.Generics (Generic)
 
 data Node lexeme
     -- Preprocessor
@@ -92,7 +96,10 @@ data Node lexeme
     -- Constants
     | ConstDecl (Node lexeme) lexeme
     | ConstDefn Scope (Node lexeme) lexeme (Node lexeme)
-    deriving (Show, Eq, Functor, Foldable, Traversable)
+    deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
+
+instance FromJSON lexeme => FromJSON (Node lexeme)
+instance ToJSON lexeme => ToJSON (Node lexeme)
 
 data AssignOp
     = AopEq
@@ -106,7 +113,10 @@ data AssignOp
     | AopMod
     | AopLsh
     | AopRsh
-    deriving (Show, Eq)
+    deriving (Show, Eq, Generic)
+
+instance FromJSON AssignOp
+instance ToJSON AssignOp
 
 data BinaryOp
     = BopNe
@@ -127,7 +137,10 @@ data BinaryOp
     | BopGt
     | BopGe
     | BopRsh
-    deriving (Show, Eq)
+    deriving (Show, Eq, Generic)
+
+instance FromJSON BinaryOp
+instance ToJSON BinaryOp
 
 data UnaryOp
     = UopNot
@@ -137,7 +150,10 @@ data UnaryOp
     | UopDeref
     | UopIncr
     | UopDecr
-    deriving (Show, Eq)
+    deriving (Show, Eq, Generic)
+
+instance FromJSON UnaryOp
+instance ToJSON UnaryOp
 
 data LiteralType
     = Char
@@ -145,9 +161,15 @@ data LiteralType
     | Bool
     | String
     | ConstId
-    deriving (Show, Eq)
+    deriving (Show, Eq, Generic)
+
+instance FromJSON LiteralType
+instance ToJSON LiteralType
 
 data Scope
     = Global
     | Static
-    deriving (Show, Eq)
+    deriving (Show, Eq, Generic)
+
+instance FromJSON Scope
+instance ToJSON Scope

--- a/src/Tokstyle/Cimple/IO.hs
+++ b/src/Tokstyle/Cimple/IO.hs
@@ -1,5 +1,6 @@
 module Tokstyle.Cimple.IO
     ( parseFile
+    , parseText
     ) where
 
 import           Control.Monad.State.Lazy (State, get, put, runState)
@@ -35,9 +36,16 @@ process stringAst = do
     Compact.getCompact <$> Compact.compactWithSharing textAst
 
 
+parseText :: Text -> IO (Either String [Node (Lexeme Text)])
+parseText contents =
+    mapM process res
+  where
+    res :: Either String [Node (Lexeme String)]
+    res = runAlex (Text.unpack contents) parseCimple
+
+
 parseFile :: FilePath -> IO (Either String [Node (Lexeme Text)])
 parseFile source = do
     putStrLn $ "Processing " ++ source
-    contents <- Text.unpack . Text.decodeUtf8 <$> BS.readFile source
-
-    mapM process $ runAlex contents parseCimple
+    contents <- Text.decodeUtf8 <$> BS.readFile source
+    parseText contents

--- a/src/Tokstyle/Cimple/Lexer.x
+++ b/src/Tokstyle/Cimple/Lexer.x
@@ -1,9 +1,12 @@
 {
-{-# LANGUAGE DeriveFunctor     #-}
-{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DeriveFunctor      #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DeriveTraversable  #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module Tokstyle.Cimple.Lexer
     ( Alex
     , AlexPosn (..)
+    , alexError
     , alexScanTokens
     , alexMonadScan
     , Lexeme (..)
@@ -15,6 +18,8 @@ module Tokstyle.Cimple.Lexer
     , runAlex
     ) where
 
+import           Data.Aeson             (FromJSON, ToJSON)
+import           GHC.Generics           (Generic)
 import           Tokstyle.Cimple.Tokens (LexemeClass (..))
 }
 
@@ -230,8 +235,15 @@ tokens :-
 <0,ppSC,cmtSC,codeSC>	.				{ mkL Error }
 
 {
+deriving instance Generic AlexPosn
+instance FromJSON AlexPosn
+instance ToJSON AlexPosn
+
 data Lexeme text = L AlexPosn LexemeClass text
-    deriving (Show, Eq, Functor, Foldable, Traversable)
+    deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
+
+instance FromJSON text => FromJSON (Lexeme text)
+instance ToJSON text => ToJSON (Lexeme text)
 
 mkL :: Applicative m => LexemeClass -> AlexInput -> Int -> m (Lexeme String)
 mkL c (p, _, _, str) len = pure $ L p c (take len str)

--- a/src/Tokstyle/Cimple/Parser.y
+++ b/src/Tokstyle/Cimple/Parser.y
@@ -4,7 +4,7 @@ module Tokstyle.Cimple.Parser where
 import           Tokstyle.Cimple.AST    (AssignOp (..), BinaryOp (..),
                                          LiteralType (..), Node (..),
                                          Scope (..), UnaryOp (..))
-import           Tokstyle.Cimple.Lexer  (Alex, AlexPosn, Lexeme (..),
+import           Tokstyle.Cimple.Lexer  (Alex, AlexPosn, Lexeme (..), alexError,
                                          alexMonadScan)
 import           Tokstyle.Cimple.Tokens (LexemeClass (..))
 }
@@ -579,7 +579,7 @@ ConstDecl
 type StringNode = Node (Lexeme String)
 
 parseError :: Show text => Lexeme text -> Alex a
-parseError = fail . show
+parseError token = alexError $ "Parse error near token: " <> show token
 
 lexwrap :: (Lexeme String -> Alex a) -> Alex a
 lexwrap = (alexMonadScan >>=)
@@ -593,7 +593,7 @@ externC
 externC (L _ _ "__cplusplus") (L _ _ "\"C\"") decls (L _ _ "__cplusplus") =
     return $ ExternC decls
 externC _ lang _ _ =
-    fail $ show lang
+    alexError $ show lang
         <> ": extern \"C\" declaration invalid (did you spell __cplusplus right?)"
 
 macroBodyStmt
@@ -603,6 +603,6 @@ macroBodyStmt
 macroBodyStmt decls (L _ _ "0") =
     return $ MacroBodyStmt decls
 macroBodyStmt _ cond =
-    fail $ show cond
+    alexError $ show cond
         <> ": macro do-while body must end in 'while (0)'"
 }

--- a/src/Tokstyle/Cimple/Tokens.hs
+++ b/src/Tokstyle/Cimple/Tokens.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE DeriveGeneric #-}
 module Tokstyle.Cimple.Tokens
     ( LexemeClass (..)
     ) where
+
+import           Data.Aeson   (FromJSON, ToJSON)
+import           GHC.Generics (Generic)
 
 data LexemeClass
     = IdConst
@@ -104,4 +108,7 @@ data LexemeClass
 
     | Error
     | Eof
-    deriving (Show, Eq, Ord)
+    deriving (Show, Eq, Generic, Ord)
+
+instance FromJSON LexemeClass
+instance ToJSON LexemeClass

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -36,6 +36,7 @@ library
     , Tokstyle.Result
   ghc-options:
       -Wall
+  hs-source-dirs:      src
   build-depends:
       base              >= 4 && < 5
     , aeson             >= 0.8.1.0
@@ -49,7 +50,6 @@ library
     , language-c
     , mtl
     , text
-  hs-source-dirs:      src
 
 executable check-c
   default-language: Haskell2010
@@ -57,10 +57,10 @@ executable check-c
       tools
   ghc-options:
       -Wall
+  main-is: check-c.hs
   build-depends:
       base < 5
     , tokstyle
-  main-is: check-c.hs
 
 executable check-cimple
   default-language: Haskell2010
@@ -68,12 +68,12 @@ executable check-cimple
       tools
   ghc-options:
       -Wall
+  main-is: check-cimple.hs
   build-depends:
       base < 5
     , text
     , tokstyle
     , text
-  main-is: check-cimple.hs
 
 executable dump-tokens
   default-language: Haskell2010
@@ -81,18 +81,22 @@ executable dump-tokens
       tools
   ghc-options:
       -Wall
+  main-is: dump-tokens.hs
   build-depends:
       base < 5
     , bytestring
     , groom
     , tokstyle
     , text
-  main-is: dump-tokens.hs
 
 executable webservice
   main-is:             webservice.hs
   ghc-options:
       -Wall
+  hs-source-dirs:      web
+  default-language:    Haskell2010
+  other-modules:
+      Tokstyle.App
   build-depends:
       base >= 4 && < 5
     , bytestring
@@ -104,10 +108,6 @@ executable webservice
     , wai-cors
     , wai-extra
     , warp
-  hs-source-dirs:      web
-  default-language:    Haskell2010
-  other-modules:
-      Tokstyle.App
 
 test-suite testsuite
   type: exitcode-stdio-1.0

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -37,7 +37,8 @@ library
   ghc-options:
       -Wall
   build-depends:
-      base >= 4 && < 5
+      base              >= 4 && < 5
+    , aeson             >= 0.8.1.0
     , array
     , bytestring
     , containers
@@ -87,6 +88,26 @@ executable dump-tokens
     , tokstyle
     , text
   main-is: dump-tokens.hs
+
+executable webservice
+  main-is:             webservice.hs
+  ghc-options:
+      -Wall
+  build-depends:
+      base >= 4 && < 5
+    , bytestring
+    , servant           >= 0.5
+    , servant-server    >= 0.5
+    , text
+    , tokstyle
+    , wai
+    , wai-cors
+    , wai-extra
+    , warp
+  hs-source-dirs:      web
+  default-language:    Haskell2010
+  other-modules:
+      Tokstyle.App
 
 test-suite testsuite
   type: exitcode-stdio-1.0

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -27,7 +27,7 @@ haskell_binary(
     srcs = ["dump-tokens.hs"],
     visibility = ["//visibility:public"],
     deps = [
-        "//hs-tokstyle:cimple-lexer",
+        "//hs-tokstyle",
         hazel_library("base"),
         hazel_library("bytestring"),
         hazel_library("groom"),

--- a/web/Tokstyle/App.hs
+++ b/web/Tokstyle/App.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE TypeOperators         #-}
+module Tokstyle.App (app) where
+
+import           Control.Monad.IO.Class   (liftIO)
+import           Data.ByteString          (ByteString)
+import           Data.Text                (Text)
+import qualified Data.Text                as Text
+import qualified Data.Text.Encoding       as Text
+import qualified Data.Text.Encoding.Error as Text
+import           Servant
+
+import           Tokstyle.Cimple.Analysis (analyse)
+import           Tokstyle.Cimple.AST      (Node)
+import qualified Tokstyle.Cimple.IO       as Cimple
+import           Tokstyle.Cimple.Lexer    (Lexeme)
+
+
+type ParseResult = Either String [Node (Lexeme Text)]
+
+-- API specification
+type TokstyleApi =
+       -- Link to the source code repository, to comply with AGPL.
+       "source" :> Get '[PlainText] String
+       -- Parse a C file as Cimple AST.
+  :<|> "parse" :> ReqBody '[OctetStream] ByteString :> Post '[JSON] ParseResult
+       -- Run all Cimple analyses and return the diagnostics as list of strings.
+  :<|> "analyse" :> ReqBody '[JSON] (FilePath, ParseResult) :> Post '[JSON] [Text]
+
+tokstyleApi :: Proxy TokstyleApi
+tokstyleApi = Proxy
+
+-- Server-side handlers.
+--
+-- There's one handler per endpoint, which, just like in the type
+-- that represents the API, are glued together using :<|>.
+--
+-- Each handler runs in the 'Handler' monad.
+server :: Server TokstyleApi
+server =
+         sourceH
+    :<|> parseH
+    :<|> analyseH
+  where
+    sourceH = return "https://github.com/TokTok/hs-tokstyle"
+
+    parseH = liftIO . Cimple.parseText . Text.decodeUtf8With Text.lenientDecode
+
+    analyseH (_   , Left  err) = return [Text.pack err]
+    analyseH (file, Right ast) = return $ analyse file ast
+
+-- Turn the server into a WAI app. 'serve' is provided by servant,
+-- more precisely by the Servant.Server module.
+app :: Application
+app = serve tokstyleApi server

--- a/web/webservice.hs
+++ b/web/webservice.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import           Network.Wai.Handler.Warp    (Port, run)
+import           Network.Wai.Middleware.Cors (simpleCors)
+import           System.Environment          (getArgs)
+import           System.IO                   (BufferMode (..), hSetBuffering,
+                                              stdout)
+
+import qualified Tokstyle.App                as App
+
+-- Run the server.
+runTestServer :: Port -> IO ()
+runTestServer port = run port $ simpleCors App.app
+
+-- Put this all to work!
+main :: IO ()
+main = do
+  -- So real time logging works correctly.
+  hSetBuffering stdout LineBuffering
+  args <- getArgs
+  case args of
+    [port] -> runTestServer $ read port
+    _      -> runTestServer 8001


### PR DESCRIPTION
These were useful because they avoid recompiling all the other code while
testing the lexer, but we now have a test that ensures cabal and bazel
agree, and this makes them disagree.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/48)
<!-- Reviewable:end -->
