### PR TITLE
Add check that LOGGER format strings contain no escapes.

### DIFF
--- a/src/Tokstyle/Cimple/Analysis.hs
+++ b/src/Tokstyle/Cimple/Analysis.hs
@@ -1,16 +1,18 @@
 module Tokstyle.Cimple.Analysis (analyse) where
 
-import           Data.Text                            (Text)
-import           Tokstyle.Cimple.AST                  (Node (..))
-import           Tokstyle.Cimple.Lexer                (Lexeme)
+import           Data.Text                                (Text)
+import           Tokstyle.Cimple.AST                      (Node (..))
+import           Tokstyle.Cimple.Lexer                    (Lexeme)
 
-import qualified Tokstyle.Cimple.Analysis.FuncScopes  as FuncScopes
-import qualified Tokstyle.Cimple.Analysis.GlobalFuncs as GlobalFuncs
-import qualified Tokstyle.Cimple.Analysis.LoggerCalls as LoggerCalls
+import qualified Tokstyle.Cimple.Analysis.FuncScopes      as FuncScopes
+import qualified Tokstyle.Cimple.Analysis.GlobalFuncs     as GlobalFuncs
+import qualified Tokstyle.Cimple.Analysis.LoggerCalls     as LoggerCalls
+import qualified Tokstyle.Cimple.Analysis.LoggerNoEscapes as LoggerNoEscapes
 
 analyse :: FilePath -> [Node (Lexeme Text)] -> [Text]
 analyse file ast = concatMap (\f -> f file ast)
     [ FuncScopes.analyse
     , GlobalFuncs.analyse
     , LoggerCalls.analyse
+    , LoggerNoEscapes.analyse
     ]

--- a/src/Tokstyle/Cimple/Analysis/LoggerNoEscapes.hs
+++ b/src/Tokstyle/Cimple/Analysis/LoggerNoEscapes.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Tokstyle.Cimple.Analysis.LoggerNoEscapes (analyse) where
+
+import           Control.Monad               (when)
+import           Control.Monad.State.Lazy    (State)
+import qualified Control.Monad.State.Lazy    as State
+import           Data.Text                   (Text, isInfixOf)
+import qualified Data.Text                   as Text
+import           Tokstyle.Cimple.AST         (LiteralType (String), Node (..))
+import qualified Tokstyle.Cimple.Diagnostics as Diagnostics
+import           Tokstyle.Cimple.Lexer       (Lexeme (..), lexemeText)
+import           Tokstyle.Cimple.TraverseAst
+
+
+linter :: FilePath -> AstActions (State [Text]) Text
+linter file = defaultActions
+    { doNode = \node act -> case node of
+            -- LOGGER_ASSERT has its format as the third parameter.
+        FunctionCall (LiteralExpr _ (L _ _ "LOGGER_ASSERT")) (_ : _ : LiteralExpr String fmt : _)
+            -> do
+                checkFormat file fmt
+                act
+
+        FunctionCall (LiteralExpr _ (L _ _ func)) (_ : LiteralExpr String fmt : _)
+            | Text.isPrefixOf "LOGGER_" func
+            -> do
+                checkFormat file fmt
+                act
+
+        _ -> act
+    }
+
+
+checkFormat :: FilePath -> Lexeme Text -> State [Text] ()
+checkFormat file fmt =
+    when ("\\" `isInfixOf` text)
+        $  Diagnostics.warn file fmt
+        $  "logger format "
+        <> text
+        <> " contains escape sequences (newlines, tabs, or escaped quotes)"
+    where text = lexemeText fmt
+
+
+analyse :: FilePath -> [Node (Lexeme Text)] -> [Text]
+analyse file ast = reverse $ State.execState (traverseAst (linter file) ast) []

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -23,6 +23,7 @@ library
     , Tokstyle.Cimple.Analysis.FuncScopes
     , Tokstyle.Cimple.Analysis.GlobalFuncs
     , Tokstyle.Cimple.Analysis.LoggerCalls
+    , Tokstyle.Cimple.Analysis.LoggerNoEscapes
     , Tokstyle.Cimple.AST
     , Tokstyle.Cimple.Diagnostics
     , Tokstyle.Cimple.IO


### PR DESCRIPTION
It's a common mistake to add an extra newline character at the end of a
LOGGER format string. These end up needlessly creating double newlines in
client log outputs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/49)
<!-- Reviewable:end -->
