### PR TITLE
Explicitly opt-out of standard Travis template.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_library")
 load("//third_party/haskell/hspec-discover:build_defs.bzl", "hspec_test")
 load("//tools/project:build_defs.bzl", "project")
 
-project()
+project(standard_travis = False)
 
 haskell_library(
     name = "hs-tokstyle",


### PR DESCRIPTION
Tokstyle needs its own .travis.yml for now, because it releases binaries,
unlike (at the moment) all other Haskell projects. Once the standard
Travis config template supports binary releases, we'll remove this
opt-out and start using that template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/55)
<!-- Reviewable:end -->
