### PR TITLE
feat: Require that for-init-decls have one of 2 formats.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.23-third_party
+    image: toxchat/toktok-stack:0.0.27-third_party
     cpu: 2
     memory: 6G
   configure_script:

--- a/src/Tokstyle/Cimple/Analysis.hs
+++ b/src/Tokstyle/Cimple/Analysis.hs
@@ -3,6 +3,7 @@ module Tokstyle.Cimple.Analysis (analyse) where
 import           Data.Text                                (Text)
 import           Language.Cimple                          (Lexeme, Node (..))
 
+import qualified Tokstyle.Cimple.Analysis.ForLoops        as ForLoops
 import qualified Tokstyle.Cimple.Analysis.FuncPrototypes  as FuncPrototypes
 import qualified Tokstyle.Cimple.Analysis.FuncScopes      as FuncScopes
 import qualified Tokstyle.Cimple.Analysis.GlobalFuncs     as GlobalFuncs
@@ -11,7 +12,8 @@ import qualified Tokstyle.Cimple.Analysis.LoggerNoEscapes as LoggerNoEscapes
 
 analyse :: FilePath -> [Node (Lexeme Text)] -> [Text]
 analyse file ast = concatMap (\f -> f file ast)
-    [ FuncPrototypes.analyse
+    [ ForLoops.analyse
+    , FuncPrototypes.analyse
     , FuncScopes.analyse
     , GlobalFuncs.analyse
     , LoggerCalls.analyse

--- a/src/Tokstyle/Cimple/Analysis/ForLoops.hs
+++ b/src/Tokstyle/Cimple/Analysis/ForLoops.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Tokstyle.Cimple.Analysis.ForLoops (analyse) where
+
+import           Control.Monad.State.Lazy    (State)
+import qualified Control.Monad.State.Lazy    as State
+import           Data.Text                   (Text)
+import qualified Data.Text                   as Text
+import           Language.Cimple             (AlexPosn (..), AssignOp (..),
+                                              Lexeme (..), LexemeClass (..),
+                                              Node (..))
+import qualified Language.Cimple.Diagnostics as Diagnostics
+import           Language.Cimple.TraverseAst (AstActions (..), defaultActions,
+                                              traverseAst)
+
+
+linter :: FilePath -> AstActions (State [Text]) Text
+linter file = defaultActions
+    { doNode = \node act ->
+        case node of
+            ForStmt (VarDecl _ty (Declarator (DeclSpecVar _i) (Just _v))) _ _ _ -> do
+                act
+
+            ForStmt (AssignExpr (VarExpr _i) AopEq _v) _ _ _ -> do
+                act
+
+            ForStmt i _ _ _ -> do
+                warn (L (AlexPn 0 0 0) KwFor "for") . Text.pack . show $ i
+                act
+
+            _ -> act
+    }
+  where warn = Diagnostics.warn file
+
+analyse :: FilePath -> [Node (Lexeme Text)] -> [Text]
+analyse file ast = reverse $ State.execState (traverseAst (linter file) ast) []

--- a/src/Tokstyle/Cimple/Analysis/GlobalFuncs.hs
+++ b/src/Tokstyle/Cimple/Analysis/GlobalFuncs.hs
@@ -11,7 +11,7 @@ import           System.FilePath             (takeExtension)
 
 analyse :: FilePath -> [Node (Lexeme Text)] -> [Text]
 analyse file _ | takeExtension file /= ".c" = []
-analyse file ast = reverse $ snd $ State.runState (mapM go ast) []
+analyse file ast = reverse $ State.execState (mapM go ast) []
   where
     go (FunctionDecl Global (FunctionPrototype _ name _) _) =
         warn file name $

--- a/test/Tokstyle/Cimple/AnalysisSpec.hs
+++ b/test/Tokstyle/Cimple/AnalysisSpec.hs
@@ -11,14 +11,14 @@ spec :: Spec
 spec =
     describe "analyse" $ do
         it "should parse a simple function" $ do
-            Right ast <- parseText "int a(void) { return 3; }"
+            let Right ast = parseText "int a(void) { return 3; }"
             analyse "test.c" ast `shouldBe` []
 
         it "should give diagnostics on extern decls in .c files" $ do
-            Right ast <- parseText "int a(void);"
+            let Right ast = parseText "int a(void);"
             analyse "test.c" ast
                 `shouldBe` ["test.c:1: global function `a' declared in .c file"]
 
         it "should not give diagnostics on extern decls in .h files" $ do
-            Right ast <- parseText "int a(void);"
+            let Right ast = parseText "int a(void);"
             analyse "test.h" ast `shouldBe` []

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -20,7 +20,8 @@ library
   exposed-modules:
       Tokstyle.Cimple.Analysis
   other-modules:
-      Tokstyle.Cimple.Analysis.FuncPrototypes
+      Tokstyle.Cimple.Analysis.ForLoops
+    , Tokstyle.Cimple.Analysis.FuncPrototypes
     , Tokstyle.Cimple.Analysis.FuncScopes
     , Tokstyle.Cimple.Analysis.GlobalFuncs
     , Tokstyle.Cimple.Analysis.LoggerCalls
@@ -33,7 +34,7 @@ library
       base              >= 4 && < 5
     , aeson             >= 0.8.1.0
     , bytestring
-    , cimple
+    , cimple            >= 0.0.2
     , containers
     , deepseq
     , filepath

--- a/tools/check-cimple.hs
+++ b/tools/check-cimple.hs
@@ -1,25 +1,31 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
+import           Data.Text                (Text)
 import qualified Data.Text.IO             as Text
-import           Language.Cimple.IO       (parseFile)
+import           Language.Cimple          (Lexeme, Node)
+import           Language.Cimple.IO       (parseProgram)
+import qualified Language.Cimple.Program  as Program
 import           System.Environment       (getArgs)
 
 import           Tokstyle.Cimple.Analysis (analyse)
 
 
-processFile :: FilePath -> IO ()
-processFile file = do
-    ast <- parseFile file >>= getRight
+processAst :: FilePath -> [Node (Lexeme Text)] -> IO ()
+processAst file ast = do
     case analyse file ast of
         [] -> return ()
         diags -> do
             mapM_ Text.putStrLn diags
             fail $ "errors found in " <> file
-  where
-    getRight (Left err) = fail err
-    getRight (Right ok) = return ok
 
 
 main :: IO ()
-main = mapM_ processFile =<< getArgs
+main =
+    getArgs
+    >>= parseProgram
+    >>= getRight
+    >>= mapM_ (uncurry processAst) . Program.toList
+  where
+    getRight (Left err) = fail err
+    getRight (Right ok) = return ok

--- a/web/Tokstyle/App.hs
+++ b/web/Tokstyle/App.hs
@@ -46,7 +46,7 @@ server =
   where
     sourceH = return "https://github.com/TokTok/hs-tokstyle"
 
-    parseH = liftIO . Cimple.parseText . Text.decodeUtf8With Text.lenientDecode
+    parseH = return . Cimple.parseText . Text.decodeUtf8With Text.lenientDecode
 
     analyseH (_   , Left  err) = return [Text.pack err]
     analyseH (file, Right ast) = return $ analyse file ast


### PR DESCRIPTION
The for loop init decl should either be a variable declaration like
`int i = 0` or an assignment like `i = 0`. This disallows for example
`int i` as an init-decl (it's uninitialised) or some random other
expression that's not an assignment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/67)
<!-- Reviewable:end -->
