### PR TITLE
feat: Check that doc comments match for function decl/defn.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.27-third_party
+    image: toxchat/toktok-stack:0.0.29-third_party
     cpu: 2
     memory: 6G
   configure_script:

--- a/src/Tokstyle/Cimple/Analysis.hs
+++ b/src/Tokstyle/Cimple/Analysis.hs
@@ -1,4 +1,7 @@
-module Tokstyle.Cimple.Analysis (analyse) where
+module Tokstyle.Cimple.Analysis
+    ( analyse
+    , analyseGlobal
+    ) where
 
 import           Data.Text                                (Text)
 import           Language.Cimple                          (Lexeme, Node (..))
@@ -10,12 +13,21 @@ import qualified Tokstyle.Cimple.Analysis.GlobalFuncs     as GlobalFuncs
 import qualified Tokstyle.Cimple.Analysis.LoggerCalls     as LoggerCalls
 import qualified Tokstyle.Cimple.Analysis.LoggerNoEscapes as LoggerNoEscapes
 
-analyse :: FilePath -> [Node (Lexeme Text)] -> [Text]
-analyse file ast = concatMap (\f -> f file ast)
+import qualified Tokstyle.Cimple.Analysis.DocComments     as DocComments
+
+type TranslationUnit = (FilePath, [Node (Lexeme Text)])
+
+analyse :: TranslationUnit -> [Text]
+analyse (file, ast) = concatMap (\f -> f file ast)
     [ ForLoops.analyse
     , FuncPrototypes.analyse
     , FuncScopes.analyse
     , GlobalFuncs.analyse
     , LoggerCalls.analyse
     , LoggerNoEscapes.analyse
+    ]
+
+analyseGlobal :: [TranslationUnit] -> [Text]
+analyseGlobal tus = concatMap ($ tus)
+    [ DocComments.analyse
     ]

--- a/src/Tokstyle/Cimple/Analysis/DocComments.hs
+++ b/src/Tokstyle/Cimple/Analysis/DocComments.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StrictData        #-}
+module Tokstyle.Cimple.Analysis.DocComments (analyse) where
+
+import           Control.Monad.State.Lazy    (State)
+import qualified Control.Monad.State.Lazy    as State
+import           Data.Text                   (Text)
+import qualified Data.Text                   as Text
+import           Language.Cimple             (AlexPosn (..), Lexeme (..),
+                                              LexemeClass (..), Node (..))
+import           Language.Cimple.Diagnostics (HasDiagnostics (..))
+import qualified Language.Cimple.Diagnostics as Diagnostics
+import           Language.Cimple.Pretty      (ppTranslationUnit)
+import           Language.Cimple.TraverseAst (AstActions (..), defaultActions,
+                                              traverseAst)
+
+
+data Linter = Linter
+    { diags :: [Text]
+    , docs  :: [(Text, (FilePath, Node (Lexeme Text)))]
+    }
+
+empty :: Linter
+empty = Linter [] []
+
+instance HasDiagnostics Linter where
+    addDiagnostic diag l@Linter{diags} = l{diags = addDiagnostic diag diags}
+
+
+linter :: AstActions (State Linter) Text
+linter = defaultActions
+    { doNode = \file node act ->
+        case node of
+            Commented doc (FunctionDecl _ (FunctionPrototype _ fn@(L _ IdVar _) _) _) -> do
+                checkCommentEquals file doc fn
+                act
+
+            Commented doc (FunctionDefn _ (FunctionPrototype _ fn@(L _ IdVar _) _) _) -> do
+                checkCommentEquals file doc fn
+                act
+
+            {-
+            Commented _ n -> do
+                warn file node . Text.pack . show $ n
+                act
+            -}
+
+            _ -> act
+    }
+  where
+    warn file = Diagnostics.warn file
+    tshow = Text.pack . show
+
+    removeSloc :: Node (Lexeme a) -> Node (Lexeme a)
+    removeSloc = fmap $ \(L _ c t) -> L (AlexPn 0 0 0) c t
+
+    checkCommentEquals file doc fn@(L _ _ fname) = do
+        l@Linter{docs} <- State.get
+        case lookup fname docs of
+            Nothing -> State.put l{docs = (fname, (file, doc)):docs}
+            Just (_, doc') | removeSloc doc == removeSloc doc' -> return ()
+            Just (file', doc') ->
+                warn file fn $ "comment on declaration does not match definition:\n"
+                    <> tshow (ppTranslationUnit [doc]) <> "\nalso defined at "
+                    <> Diagnostics.sloc file' (Diagnostics.at doc') <> ":\n"
+                    <> tshow (ppTranslationUnit [doc'])
+
+analyse :: [(FilePath, [Node (Lexeme Text)])] -> [Text]
+analyse tus = reverse . diags $ State.execState (traverseAst linter tus) empty

--- a/src/Tokstyle/Cimple/Analysis/FuncPrototypes.hs
+++ b/src/Tokstyle/Cimple/Analysis/FuncPrototypes.hs
@@ -9,17 +9,16 @@ import qualified Language.Cimple.Diagnostics as Diagnostics
 import           Language.Cimple.TraverseAst
 
 
-linter :: FilePath -> AstActions (State [Text]) Text
-linter file = defaultActions
-    { doNode = \node act ->
+linter :: AstActions (State [Text]) Text
+linter = defaultActions
+    { doNode = \file node act ->
         case node of
             FunctionPrototype _ name [] -> do
-                warn name "empty parameter list must be written as (void)"
+                Diagnostics.warn file name "empty parameter list must be written as (void)"
                 act
 
             _ -> act
     }
-  where warn = Diagnostics.warn file
 
 analyse :: FilePath -> [Node (Lexeme Text)] -> [Text]
-analyse file ast = reverse $ State.execState (traverseAst (linter file) ast) []
+analyse file ast = reverse $ State.execState (traverseAst linter (file, ast)) []

--- a/src/Tokstyle/Cimple/Analysis/LoggerNoEscapes.hs
+++ b/src/Tokstyle/Cimple/Analysis/LoggerNoEscapes.hs
@@ -12,9 +12,9 @@ import qualified Language.Cimple.Diagnostics as Diagnostics
 import           Language.Cimple.TraverseAst
 
 
-linter :: FilePath -> AstActions (State [Text]) Text
-linter file = defaultActions
-    { doNode = \node act -> case node of
+linter :: AstActions (State [Text]) Text
+linter = defaultActions
+    { doNode = \file node act -> case node of
             -- LOGGER_ASSERT has its format as the third parameter.
         FunctionCall (LiteralExpr _ (L _ _ "LOGGER_ASSERT")) (_ : _ : LiteralExpr String fmt : _)
             -> do
@@ -42,4 +42,4 @@ checkFormat file fmt =
 
 
 analyse :: FilePath -> [Node (Lexeme Text)] -> [Text]
-analyse file ast = reverse $ State.execState (traverseAst (linter file) ast) []
+analyse file ast = reverse $ State.execState (traverseAst linter (file, ast)) []

--- a/test/Tokstyle/Cimple/AnalysisSpec.hs
+++ b/test/Tokstyle/Cimple/AnalysisSpec.hs
@@ -12,13 +12,13 @@ spec =
     describe "analyse" $ do
         it "should parse a simple function" $ do
             let Right ast = parseText "int a(void) { return 3; }"
-            analyse "test.c" ast `shouldBe` []
+            analyse ("test.c", ast) `shouldBe` []
 
         it "should give diagnostics on extern decls in .c files" $ do
             let Right ast = parseText "int a(void);"
-            analyse "test.c" ast
+            analyse ("test.c", ast)
                 `shouldBe` ["test.c:1: global function `a' declared in .c file"]
 
         it "should not give diagnostics on extern decls in .h files" $ do
             let Right ast = parseText "int a(void);"
-            analyse "test.h" ast `shouldBe` []
+            analyse ("test.h", ast) `shouldBe` []

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -20,7 +20,8 @@ library
   exposed-modules:
       Tokstyle.Cimple.Analysis
   other-modules:
-      Tokstyle.Cimple.Analysis.ForLoops
+      Tokstyle.Cimple.Analysis.DocComments
+    , Tokstyle.Cimple.Analysis.ForLoops
     , Tokstyle.Cimple.Analysis.FuncPrototypes
     , Tokstyle.Cimple.Analysis.FuncScopes
     , Tokstyle.Cimple.Analysis.GlobalFuncs
@@ -34,7 +35,7 @@ library
       base              >= 4 && < 5
     , aeson             >= 0.8.1.0
     , bytestring
-    , cimple            >= 0.0.2
+    , cimple            >= 0.0.3
     , containers
     , deepseq
     , filepath

--- a/web/Tokstyle/App.hs
+++ b/web/Tokstyle/App.hs
@@ -49,7 +49,7 @@ server =
     parseH = return . Cimple.parseText . Text.decodeUtf8With Text.lenientDecode
 
     analyseH (_   , Left  err) = return [Text.pack err]
-    analyseH (file, Right ast) = return $ analyse file ast
+    analyseH (file, Right ast) = return $ analyse (file, ast)
 
 -- Turn the server into a WAI app. 'serve' is provided by servant,
 -- more precisely by the Servant.Server module.


### PR DESCRIPTION
This currently only works for Doxygen comments, i.e. ones starting with
`/**`. This is because we can't distinguish between random comments in
the middle of the file and function comments. Ultimately, we'll want all
function comments to be doxygen style comments anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/68)
<!-- Reviewable:end -->
