### PR TITLE
Restyle chore: Check that GitHub release name matches the one in BUILD.bazel.

### DIFF
--- a/.github/check_release
+++ b/.github/check_release
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+import requests
+
+bzl_data = {}
+
+def glob(*args, **kwargs):
+    pass
+
+def load(*args):
+    pass
+
+def project(**kwargs):
+    pass
+
+def hazel_library(pkg):
+    return pkg
+
+def haskell_library(version, **kwargs):
+    bzl_data["version"] = version
+
+def hspec_test(**kwargs):
+    pass
+
+
+resp = requests.get(
+        "https://api.github.com/repos/TokTok/hs-tokstyle/releases",
+        auth=(os.environ["GH_USER"], os.environ["GH_TOKEN"]))
+release = resp.json()[0]
+if release["draft"]:
+    with open("BUILD.bazel", "r") as fh:
+        exec(fh.read())
+    gh_release = release["name"][1:]
+    bzl_release = bzl_data["version"]
+    if gh_release != bzl_release:
+        print(f"Latest GitHub draft release {gh_release} does not match BUILD.bazel {bzl_release}")
+        sys.exit(1)

--- a/.github/check_release
+++ b/.github/check_release
@@ -33,7 +33,8 @@ def hspec_test(**kwargs):
 
 resp = requests.get(
     "https://api.github.com/repos/TokTok/hs-tokstyle/releases",
-    auth=(os.environ["GH_USER"], os.environ["GH_TOKEN"]))
+    auth=(os.environ["GH_USER"], os.environ["GH_TOKEN"]),
+)
 release = resp.json()[0]
 if release["draft"]:
     with open("BUILD.bazel", "r") as fh:
@@ -42,5 +43,6 @@ if release["draft"]:
     bzl_release = bzl_data["version"]
     if gh_release != bzl_release:
         print(
-            f"Latest GitHub draft release {gh_release} does not match BUILD.bazel {bzl_release}")
+            f"Latest GitHub draft release {gh_release} does not match BUILD.bazel {bzl_release}"
+        )
         sys.exit(1)

--- a/.github/check_release
+++ b/.github/check_release
@@ -6,28 +6,34 @@ import requests
 
 bzl_data = {}
 
+
 def glob(*args, **kwargs):
     pass
+
 
 def load(*args):
     pass
 
+
 def project(**kwargs):
     pass
+
 
 def hazel_library(pkg):
     return pkg
 
+
 def haskell_library(version, **kwargs):
     bzl_data["version"] = version
+
 
 def hspec_test(**kwargs):
     pass
 
 
 resp = requests.get(
-        "https://api.github.com/repos/TokTok/hs-tokstyle/releases",
-        auth=(os.environ["GH_USER"], os.environ["GH_TOKEN"]))
+    "https://api.github.com/repos/TokTok/hs-tokstyle/releases",
+    auth=(os.environ["GH_USER"], os.environ["GH_TOKEN"]))
 release = resp.json()[0]
 if release["draft"]:
     with open("BUILD.bazel", "r") as fh:
@@ -35,5 +41,6 @@ if release["draft"]:
     gh_release = release["name"][1:]
     bzl_release = bzl_data["version"]
     if gh_release != bzl_release:
-        print(f"Latest GitHub draft release {gh_release} does not match BUILD.bazel {bzl_release}")
+        print(
+            f"Latest GitHub draft release {gh_release} does not match BUILD.bazel {bzl_release}")
         sys.exit(1)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,18 @@ on:
     branches: [master]
 
 jobs:
+  check-release:
+  build-cabal:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check version against GitHub releases
+        env:
+          GH_USER: ${{ secrets.GH_USER }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: .github/check_release
+
   build-cabal:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION

A duplicate of #82 with additional commits that automatically address
incorrect style, created by [Restyled][].

Since the original Pull Request was opened as a fork in a contributor's
repository, we are unable to create a Pull Request branching from it with only
the style fixes.

The following Restylers made fixes:

- autopep8
- black


To incorporate these changes, you can either:

1. Merge this Pull Request *instead of* the original, or

1. Ask your contributor to locally incorporate these commits and push them to
   the original Pull Request

   <details>
       <summary>Expand for example instructions</summary>

       ```console
       git remote add upstream https://github.com/TokTok/hs-tokstyle.git
       git fetch upstream pull/<this PR number>/head
       git merge --ff-only FETCH_HEAD
       git push
       ```

   </details>


**NOTE**: As work continues on the original Pull Request, this process will
re-run and update (force-push) this Pull Request with updated style fixes as
necessary. If the style is fixed manually at any point (i.e. this process finds
no fixes to make), this Pull Request will be closed automatically.

Sorry if this was unexpected. To disable it, see our [documentation][].

[restyled]: https://restyled.io
[documentation]: https://github.com/restyled-io/restyled.io/wiki/Disabling-Restyled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/83)
<!-- Reviewable:end -->
