### PR TITLE
chore: Use standard CI workflow now that it's downgraded.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,3 @@ on:
 jobs:
   build:
     uses: TokTok/ci-tools/.github/workflows/haskell-ci.yml@master
-    with:
-      ghc-version: "8.10.3"
-      cabal-version: "3.2"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_library")
 load("//third_party/haskell/hspec-discover:build_defs.bzl", "hspec_test")
 load("//tools/project:build_defs.bzl", "project")
 
-project(custom_github = True)
+project()
 
 haskell_library(
     name = "hs-tokstyle",


### PR DESCRIPTION
Lots of stuff doesn't work with ghc 9, so it's all back to 8.10.3 now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/94)
<!-- Reviewable:end -->
