### PR TITLE
feat: Show suggestions for misspelled defns.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,7 @@ haskell_library(
         hazel_library("containers"),
         hazel_library("data-fix"),
         hazel_library("deepseq"),
+        hazel_library("edit-distance"),
         hazel_library("filepath"),
         hazel_library("groom"),
         hazel_library("mtl"),

--- a/src/Tokstyle/Linter/TypeCheck.hs
+++ b/src/Tokstyle/Linter/TypeCheck.hs
@@ -5,17 +5,42 @@ module Tokstyle.Linter.TypeCheck where
 
 import qualified Control.Monad.State.Strict as State
 import           Data.Fix                   (Fix (..))
+import           Data.Map                   (Map)
+import qualified Data.Map                   as Map
 import           Data.Text                  (Text)
 import           Language.Cimple            (AstActions', Lexeme, Node,
                                              NodeF (..), defaultActions',
                                              doNode, traverseAst)
 
-linter :: AstActions' [Text]
-linter = defaultActions'
+newtype Env = Env
+    { types :: Types
+    }
+    deriving (Show)
+
+type Types = Map Text Type
+data Type
+    = Aggregate Tag Members
+    | Builtin Text
+    deriving (Show)
+
+data Tag
+    = StructTag
+    | UnionTag
+    deriving (Show)
+
+type Members = Map Text Member
+data Member = Member Text Type
+    deriving (Show)
+
+empty :: Env
+empty = Env Map.empty
+
+getTypes :: AstActions' Env
+getTypes = defaultActions'
     { doNode = \_file node act ->
         case node of
-            -- Ignore everything inside functions, we'll type-check them later.
-            Fix FunctionDefn{} ->
+            Fix Typedef{} -> do
+                --_ <- error $ show $ node
                 return node
 
             -- TODO(iphydf): Implement the rest of the typecheck (draw the rest
@@ -24,5 +49,25 @@ linter = defaultActions'
             _ -> act
     }
 
+linter :: Env -> AstActions' [Text]
+linter _ = defaultActions'
+    { doNode = \_file node act ->
+        case node of
+            -- Ignore everything inside functions, we'll type-check them later.
+            Fix FunctionDefn{} ->
+                return node
+
+            _ -> act
+    }
+
 analyse :: [(FilePath, [Node (Lexeme Text)])] -> [Text]
-analyse = reverse . flip State.execState [] . traverseAst linter
+analyse tus =
+    reverse
+    . flip State.execState []
+    . traverseAst (linter env)
+    $ tus
+  where
+    env =
+        flip State.execState empty
+        . traverseAst getTypes
+        $ tus

--- a/src/Tokstyle/Linter/TypedefName.hs
+++ b/src/Tokstyle/Linter/TypedefName.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
 {-# LANGUAGE StrictData        #-}
@@ -16,14 +15,17 @@ import           Language.Cimple.Diagnostics (warn')
 linter :: AstActions' [Text]
 linter = defaultActions'
     { doNode = \file node act ->
-        case node of
-            Fix (Typedef (Fix (Struct sname _)) tname) | lexemeText sname /= lexemeText tname -> do
+        case unFix node of
+            Typedef (Fix (TyStruct sname)) tname | lexemeText sname /= lexemeText tname -> do
                 warn' file sname $ warning "struct" tname sname
                 return node
-            Fix (Typedef (Fix (Union uname _)) tname) | lexemeText uname /= lexemeText tname -> do
+            Typedef (Fix (Struct sname _)) tname | lexemeText sname /= lexemeText tname -> do
+                warn' file sname $ warning "struct" tname sname
+                return node
+            Typedef (Fix (Union uname _)) tname | lexemeText uname /= lexemeText tname -> do
                 warn' file uname $ warning "union" tname uname
                 return node
-            Fix (EnumDecl ename _ tname) | lexemeText ename /= lexemeText tname -> do
+            EnumDecl ename _ tname | lexemeText ename /= lexemeText tname -> do
                 warn' file ename $ warning "union" tname ename
                 return node
 


### PR DESCRIPTION
This now also works for structs, if you have a `typedef struct Foo Foo`
that's missing an actual `struct Foo {...}`.