### PR TITLE
feat: Check that `malloc` is only used for builtin types.

### DIFF
--- a/src/Tokstyle/Linter.hs
+++ b/src/Tokstyle/Linter.hs
@@ -15,6 +15,7 @@ import qualified Tokstyle.Linter.GlobalFuncs      as GlobalFuncs
 import qualified Tokstyle.Linter.LoggerCalls      as LoggerCalls
 import qualified Tokstyle.Linter.LoggerConst      as LoggerConst
 import qualified Tokstyle.Linter.LoggerNoEscapes  as LoggerNoEscapes
+import qualified Tokstyle.Linter.MallocType       as MallocType
 import qualified Tokstyle.Linter.Parens           as Parens
 import qualified Tokstyle.Linter.TypedefName      as TypedefName
 import qualified Tokstyle.Linter.VarUnusedInScope as VarUnusedInScope
@@ -38,6 +39,7 @@ analyse tu = concatMap ($ tu)
     , LoggerCalls.analyse
     , LoggerConst.analyse
     , LoggerNoEscapes.analyse
+    , MallocType.analyse
     , Parens.analyse
     , TypedefName.analyse
     , VarUnusedInScope.analyse

--- a/src/Tokstyle/Linter/MallocType.hs
+++ b/src/Tokstyle/Linter/MallocType.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict            #-}
+{-# LANGUAGE StrictData        #-}
+module Tokstyle.Linter.MallocType (analyse) where
+
+import           Control.Monad.State.Strict  (State)
+import qualified Control.Monad.State.Strict  as State
+import           Data.Fix                    (Fix (..))
+import           Data.Text                   (Text)
+import           Language.Cimple             (IdentityActions, Lexeme (..),
+                                              Node, NodeF (..), defaultActions,
+                                              doNode, traverseAst)
+import           Language.Cimple.Diagnostics (warn)
+
+supportedTypes :: [Text]
+supportedTypes = ["uint8_t", "int16_t", "IP_ADAPTER_INFO"]
+
+checkType :: FilePath -> Node (Lexeme Text) -> State [Text] ()
+checkType file castTy = case unFix castTy of
+    TyPointer (Fix (TyStd (L _ _ tyName))) | tyName `elem` supportedTypes -> return ()
+    _ -> warn file castTy $
+        "`malloc' should be used for builtin types only "
+        <> "(e.g. `uint8_t *' or `int16_t *'); use `calloc' instead"
+
+
+linter :: IdentityActions (State [Text]) Text
+linter = defaultActions
+    { doNode = \file node act ->
+        case unFix node of
+            CastExpr castTy (Fix (FunctionCall (Fix (VarExpr (L _ _ "malloc"))) _)) -> do
+                checkType file castTy
+                return node
+
+            FunctionCall (Fix (VarExpr (L _ _ "malloc"))) _ -> do
+                warn file node "the result of `malloc' must be cast; plain `void *' is not supported"
+                return node
+
+            _ -> act
+    }
+
+analyse :: (FilePath, [Node (Lexeme Text)]) -> [Text]
+analyse = reverse . flip State.execState [] . traverseAst linter

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -32,6 +32,7 @@ library
     , Tokstyle.Linter.LoggerCalls
     , Tokstyle.Linter.LoggerConst
     , Tokstyle.Linter.LoggerNoEscapes
+    , Tokstyle.Linter.MallocType
     , Tokstyle.Linter.Parens
     , Tokstyle.Linter.TypeCheck
     , Tokstyle.Linter.TypedefName


### PR DESCRIPTION
It's used for byte arrays and one exemption in `LAN_discovery.c` because
of Microsoft® Windows™ Weirdness™. Generally, we should use calloc just
to be safe and have zero-initialised data structures. For byte and int16
arrays, we allow uninitialised allocations for efficiency reasons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/103)
<!-- Reviewable:end -->
