### PR TITLE
feat: Check that memcpy is not used where assignment could be used.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,6 +5,8 @@ load("//tools/project:build_defs.bzl", "project")
 
 project()
 
+package(features = ["-layering_check"])
+
 haskell_library(
     name = "hs-tokstyle",
     srcs = glob(["src/**/*.*hs"]),

--- a/src/Tokstyle/Linter.hs
+++ b/src/Tokstyle/Linter.hs
@@ -16,6 +16,7 @@ import qualified Tokstyle.Linter.LoggerCalls      as LoggerCalls
 import qualified Tokstyle.Linter.LoggerConst      as LoggerConst
 import qualified Tokstyle.Linter.LoggerNoEscapes  as LoggerNoEscapes
 import qualified Tokstyle.Linter.MallocType       as MallocType
+import qualified Tokstyle.Linter.MemcpyStructs    as MemcpyStructs
 import qualified Tokstyle.Linter.Parens           as Parens
 import qualified Tokstyle.Linter.TypedefName      as TypedefName
 import qualified Tokstyle.Linter.VarUnusedInScope as VarUnusedInScope
@@ -40,6 +41,7 @@ analyse tu = concatMap ($ tu)
     , LoggerConst.analyse
     , LoggerNoEscapes.analyse
     , MallocType.analyse
+    , MemcpyStructs.analyse
     , Parens.analyse
     , TypedefName.analyse
     , VarUnusedInScope.analyse

--- a/src/Tokstyle/Linter/MemcpyStructs.hs
+++ b/src/Tokstyle/Linter/MemcpyStructs.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict            #-}
+{-# LANGUAGE StrictData        #-}
+module Tokstyle.Linter.MemcpyStructs (analyse) where
+
+import           Control.Monad.State.Strict  (State)
+import qualified Control.Monad.State.Strict  as State
+import           Data.Fix                    (Fix (..))
+import           Data.Text                   (Text)
+import           Language.Cimple             (IdentityActions, Lexeme (..),
+                                              Node, NodeF (..), defaultActions,
+                                              doNode, traverseAst)
+import           Language.Cimple.Diagnostics (warn)
+import           Language.Cimple.Pretty      (showNode)
+
+exemptions :: [Text]
+exemptions =
+    [ "Cmp_data"
+    , "DHT_Cmp_data"
+    , "IP_Port"
+    , "IP4"
+    , "IP6"
+    , "Node_format"
+    , "Onion_Client_Cmp_data"
+    ]
+
+checkSize :: FilePath -> Node (Lexeme Text) -> State [Text] ()
+checkSize file size = case unFix size of
+    SizeofType ty@(Fix (TyUserDefined (L _ _ name))) | not $ name `elem` exemptions ->
+        warn file size $
+            "`memcpy' should not be used for structs like `"
+            <> showNode ty <> "' - use assignment instead"
+
+    _ -> return ()
+
+
+linter :: IdentityActions (State [Text]) Text
+linter = defaultActions
+    { doNode = \file node act ->
+        case unFix node of
+            FunctionCall (Fix (VarExpr (L _ _ "memcpy"))) [_, _, size] -> do
+                checkSize file size
+                return node
+
+            _ -> act
+    }
+
+analyse :: (FilePath, [Node (Lexeme Text)]) -> [Text]
+analyse = reverse . flip State.execState [] . traverseAst linter

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -33,6 +33,7 @@ library
     , Tokstyle.Linter.LoggerConst
     , Tokstyle.Linter.LoggerNoEscapes
     , Tokstyle.Linter.MallocType
+    , Tokstyle.Linter.MemcpyStructs
     , Tokstyle.Linter.Parens
     , Tokstyle.Linter.TypeCheck
     , Tokstyle.Linter.TypedefName

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@ai_formation_hazel//tools:mangling.bzl", "hazel_library")
 load("@rules_haskell//haskell:defs.bzl", "haskell_binary")
 
+package(features = ["-layering_check"])
+
 haskell_binary(
     name = "check-cimple",
     srcs = ["check-cimple.hs"],

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@ai_formation_hazel//tools:mangling.bzl", "hazel_library")
 load("@rules_haskell//haskell:defs.bzl", "haskell_binary")
 
+package(features = ["-layering_check"])
+
 haskell_binary(
     name = "webservice",
     srcs = glob(["**/*.hs"]),


### PR DESCRIPTION
`memcpy` doesn't do any type checking, so there's no guarantee that the
thing copied from is the same type as the thing copied to. Sometimes
that's useful, but most of the time it's potentially unsafe. Usually it's
also more typing than a simple assignment. E.g.

```c
memcpy(&some_struct, &other_struct, sizeof(Struct_Type));
```

vs.

```c
some_struct = other_struct;
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/104)
<!-- Reviewable:end -->
