### PR TITLE
perf: Run tokstyle checkers in parallel.

### DIFF
--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -64,6 +64,7 @@ executable check-cimple
   build-depends:
       base < 5
     , cimple
+    , parallel
     , text
     , tokstyle
 

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -4,11 +4,13 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_binary")
 haskell_binary(
     name = "check-cimple",
     srcs = ["check-cimple.hs"],
+    compiler_flags = ["-threaded"],
     visibility = ["//visibility:public"],
     deps = [
         "//hs-cimple",
         "//hs-tokstyle",
         hazel_library("base"),
+        hazel_library("parallel"),
         hazel_library("text"),
     ],
 )

--- a/tools/check-cimple.hs
+++ b/tools/check-cimple.hs
@@ -2,19 +2,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
-import           Data.Text          (Text)
-import qualified Data.Text.IO       as Text
-import           Language.Cimple    (Lexeme, Node)
-import           Language.Cimple.IO (parseFiles)
-import           System.Environment (getArgs)
+import           Control.Parallel.Strategies (parMap, rpar)
+import           Data.Text                   (Text)
+import qualified Data.Text.IO                as Text
+import           Language.Cimple             (Lexeme, Node)
+import           Language.Cimple.IO          (parseFiles)
+import           System.Environment          (getArgs)
 
-import           Tokstyle.Linter    (analyse, analyseGlobal)
+import           Tokstyle.Linter             (analyse, analyseGlobal)
 
 
 processAst :: [(FilePath, [Node (Lexeme Text)])] -> IO ()
-processAst tus = do
-    report $ analyseGlobal tus
-    mapM_ (report . analyse) tus
+processAst tus = report $ concat $ analyseGlobal tus : parMap rpar analyse tus
   where
     report = \case
         [] -> return ()


### PR DESCRIPTION
This saves about 25-28% of overall wallclock time when running with 3 or
4 cores (on my machine).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/106)
<!-- Reviewable:end -->
