### PR TITLE
feat: Add more functions to the unsafe list with explanations.

### DIFF
--- a/src/Tokstyle/Linter/MallocType.hs
+++ b/src/Tokstyle/Linter/MallocType.hs
@@ -13,7 +13,7 @@ import           Language.Cimple             (IdentityActions, Lexeme (..),
 import           Language.Cimple.Diagnostics (warn)
 
 supportedTypes :: [Text]
-supportedTypes = ["uint8_t", "int16_t", "IP_ADAPTER_INFO"]
+supportedTypes = ["char", "uint8_t", "int16_t", "IP_ADAPTER_INFO"]
 
 checkType :: FilePath -> Node (Lexeme Text) -> State [Text] ()
 checkType file castTy = case unFix castTy of

--- a/src/Tokstyle/Linter/UnsafeFunc.hs
+++ b/src/Tokstyle/Linter/UnsafeFunc.hs
@@ -8,33 +8,41 @@ module Tokstyle.Linter.UnsafeFunc (analyse) where
 import           Control.Monad.State.Strict  (State)
 import qualified Control.Monad.State.Strict  as State
 import           Data.Fix                    (Fix (..))
+import           Data.Maybe                  (fromMaybe)
 import           Data.Text                   (Text)
 import           Language.Cimple             (IdentityActions, Lexeme (..),
                                               Node, NodeF (..), defaultActions,
                                               doNode, traverseAst)
 import           Language.Cimple.Diagnostics (warn)
 
-forbidden :: [(Text, Text)]
+forbidden :: [(Text, (Text, Maybe Text))]
 forbidden =
-    [ ("atexit", "this creates global state that should be avoided")
-    , ("atoi", "use `strtol' instead")
-    , ("sprintf", "use `snprintf' instead")
-    , ("strcat", "use `snprintf' instead")
-    , ("strchr", "use `memchr' instead")
-    , ("strcmp", "use `memcmp' instead")
-    , ("strcpy", "use `snprintf' instead")
-    , ("strdup", "use `malloc' followed by `memcpy' instead")
+    [ ("atexit"  , ("creates global state that should be avoided"            , Nothing))
+    , ("atof"    , ("does not perform error checking"                        , Just "strtod"))
+    , ("atoi"    , ("does not perform error checking"                        , Just "strtol"))
+    , ("atoll"   , ("does not perform error checking"                        , Just "strtoll"))
+    , ("atol"    , ("does not perform error checking"                        , Just "strtol"))
+    , ("gets"    , ("performs unbounded writes to buffers"                   , Just "fgets"))
+    , ("sprintf" , ("has no way of bounding the number of characters written", Just "snprintf"))
+    , ("strerror", ("is not thread safe"                                     , Just "strerror_r or net_new_strerror"))
+    , ("strcat"  , ("has no way of bounding the number of characters written", Just "snprintf"))
+    , ("strcpy"  , ("has no way of bounding the number of characters written", Just "snprintf or strlen and memcpy"))
+    , ("strncpy" , ("may not null-terminate the target string"               , Just "snprintf or strlen and memcpy"))
+    , ("strdup"  , ("is non-portable"                                        , Just "malloc followed by memcpy"))
+    , ("strtok"  , ("is not thread-safe"                                     , Nothing))
+    , ("vsprintf", ("has no way of bounding the number of characters written", Just "vsnprintf"))
     ]
 
-checkName :: Text -> Maybe (Text, Text)
+checkName :: Text -> Maybe (Text, (Text, Maybe Text))
 checkName name = (name,) <$> lookup name forbidden
 
 linter :: IdentityActions (State [Text]) Text
 linter = defaultActions
     { doNode = \file node act ->
         case unFix node of
-            FunctionCall (Fix (VarExpr (L _ _ (checkName -> Just (name, msg))))) _ -> do
-                warn file node $ "function `" <> name <> "' should not be used; " <> msg
+            FunctionCall (Fix (VarExpr (L _ _ (checkName -> Just (name, (msg, replacement)))))) _ -> do
+                warn file node $ "function `" <> name <> "' should not be used, because it " <> msg
+                    <> fromMaybe "" ((\r -> "; use " <> r <> " instead") <$> replacement)
                 return node
 
             _ -> act


### PR DESCRIPTION
It will look like:
```
c-toxcore/toxcore/Messenger.c:2478: function `sprintf' should not be used, because it has no way of bounding the number of characters written; use snprintf instead
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/110)
<!-- Reviewable:end -->
