### PR TITLE
cleanup: Remove `Cmp_data` exemptions.

### DIFF
--- a/src/Tokstyle/Linter/MemcpyStructs.hs
+++ b/src/Tokstyle/Linter/MemcpyStructs.hs
@@ -15,13 +15,10 @@ import           Language.Cimple.Pretty      (showNode)
 
 exemptions :: [Text]
 exemptions =
-    [ "Cmp_data"
-    , "DHT_Cmp_data"
-    , "IP_Port"
+    [ "IP_Port"
     , "IP4"
     , "IP6"
     , "Node_format"
-    , "Onion_Client_Cmp_data"
     ]
 
 checkSize :: FilePath -> Node (Lexeme Text) -> State [Text] ()


### PR DESCRIPTION
These are now fixed in toxcore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/112)
<!-- Reviewable:end -->
