### PR TITLE
feat: Add support for everything needed by toxav.

### DIFF
--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "stdint.h"

--- a/include/opus
+++ b/include/opus
@@ -1,0 +1,1 @@
+/usr/include/opus

--- a/include/pthread.h
+++ b/include/pthread.h
@@ -16,6 +16,7 @@ typedef struct pthread_mutex_t pthread_mutex_t;
 int pthread_mutex_init(pthread_mutex_t *mutex, pthread_mutexattr_t *flags);
 void pthread_mutex_destroy(pthread_mutex_t *mutex);
 void pthread_mutex_lock(pthread_mutex_t *mutex);
+_Bool pthread_mutex_trylock(pthread_mutex_t *mutex);
 void pthread_mutex_unlock(pthread_mutex_t *mutex);
 
 typedef struct pthread_rwlock_t pthread_rwlock_t;

--- a/include/vpx
+++ b/include/vpx
@@ -1,0 +1,1 @@
+/usr/include/vpx

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -87,7 +87,7 @@ executable check-c
       base < 5
     , containers
     , language-c
-    , text
+    , monad-parallel
 
 executable webservice
   main-is:             webservice.hs

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -23,12 +23,21 @@ haskell_binary(
 haskell_binary(
     name = "check-c",
     srcs = ["check-c.hs"],
-    compiler_flags = ["-Wwarn"],
+    args = [
+        "+RTS",
+        "-N5",
+        "-RTS",
+    ],
+    compiler_flags = [
+        "-Wwarn",
+        "-rtsopts",
+        "-threaded",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         hazel_library("base"),
         hazel_library("containers"),
         hazel_library("language-c"),
-        hazel_library("text"),
+        hazel_library("monad-parallel"),
     ],
 )


### PR DESCRIPTION
Also we now disallow implicit `bool` conversion from `unsigned int`.
We allow `int`, because in C, `a == b` has type `int`. We'll gradually
disallow the use of `int` in toxcore and require sized ints (`intNN_t`)
everywhere. Then we'll also disallow implicit conversion from sized int
to bool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/130)
<!-- Reviewable:end -->
