### PR TITLE
fix: Remove exemption for binary expressions in if stmts.

### DIFF
--- a/tools/check-c.hs
+++ b/tools/check-c.hs
@@ -157,9 +157,6 @@ checkExpr (CCompoundLit d i _) = do
 checkExpr expr = throwTravError $ userErr $ "expr: " <> show expr
 
 checkStmt :: MonadTrav m => Stmt -> m ()
-checkStmt (CIf CBinary{} t e _) = do
-    checkStmt t
-    maybeM e checkStmt
 checkStmt (CIf cond t e _) = do
     checkBoolConversion cond
     checkExpr cond


### PR DESCRIPTION
We've fixed all of these now, so the check can be enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/139)
<!-- Reviewable:end -->
