### PR TITLE
feat: Disallow parens in assignment expressions.

### DIFF
--- a/src/Tokstyle/Linter/Parens.hs
+++ b/src/Tokstyle/Linter/Parens.hs
@@ -42,6 +42,9 @@ linter = astActions
             VarDeclStmt _ (Just (Fix ParenExpr{})) -> do
                 warn file node "variable initialiser does not need parentheses"
                 act
+            AssignExpr _ _ (Fix ParenExpr{}) -> do
+                warn file node "the right hand side of assignments does not need parentheses"
+                act
             ParenExpr expr | not $ needsParens expr -> do
                 warn file node "expression does not need parentheses"
                 act


### PR DESCRIPTION
E.g. `a = (3)` or `a = (3 * 2)` should not have parentheses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/150)
<!-- Reviewable:end -->
