### PR TITLE
feat: Add check for functions that could return `bool`.

### DIFF
--- a/src/Tokstyle/Linter.hs
+++ b/src/Tokstyle/Linter.hs
@@ -8,6 +8,7 @@ module Tokstyle.Linter
 import           Data.Text                         (Text)
 import           Language.Cimple                   (Lexeme, Node)
 
+import qualified Tokstyle.Linter.BooleanReturn     as BooleanReturn
 import qualified Tokstyle.Linter.Booleans          as Booleans
 import qualified Tokstyle.Linter.CallbackNames     as CallbackNames
 import qualified Tokstyle.Linter.CallocArgs        as CallocArgs
@@ -48,6 +49,7 @@ run linters flags tu =
 localLinters :: [(Text, (FilePath, [Node (Lexeme Text)]) -> [Text])]
 localLinters =
     [ ("booleans"           , Booleans.analyse         )
+    , ("boolean-return"     , BooleanReturn.analyse    )
     , ("callback-names"     , CallbackNames.analyse    )
     , ("calloc-args"        , CallocArgs.analyse       )
     , ("calloc-type"        , CallocType.analyse       )

--- a/src/Tokstyle/Linter/BooleanReturn.hs
+++ b/src/Tokstyle/Linter/BooleanReturn.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE DeriveFunctor     #-}
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict            #-}
+{-# LANGUAGE StrictData        #-}
+module Tokstyle.Linter.BooleanReturn where
+
+import           Control.Monad.State.Strict  (State)
+import qualified Control.Monad.State.Strict  as State
+import           Data.Fix                    (Fix (..), foldFix)
+import qualified Data.List                   as List
+import qualified Data.Maybe                  as Maybe
+import           Data.Text                   (Text)
+import qualified Data.Text                   as Text
+import           Language.Cimple             (Lexeme (..), LiteralType (..),
+                                              Node, NodeF (..), UnaryOp (..),
+                                              lexemeText)
+import           Language.Cimple.Diagnostics (warn)
+import           Language.Cimple.TraverseAst (AstActions, astActions, doNode,
+                                              traverseAst)
+
+
+data Value a
+    = Const a
+    | NonConst
+    | Returned (Value a)
+    deriving (Show, Functor)
+
+emptyIfAnyNonConst :: [Value a] -> [Value a]
+emptyIfAnyNonConst values =
+    if any isNonConst values then [] else values
+  where
+    isNonConst (Returned NonConst) = True
+    isNonConst _                   = False
+
+returnedConstValues :: Node (Lexeme Text) -> [Text]
+returnedConstValues = List.sort . List.nub . Maybe.mapMaybe returnedConst . emptyIfAnyNonConst . foldFix go
+  where
+    go (LiteralExpr Int (L _ _ value)) = [Const value]
+    go (Return (Just value))           = map Returned value
+    go (UnaryExpr op e)                = map (fmap (uopToken op <>)) e
+
+    go n                               = map toNonConst $ foldr (++) [NonConst] n
+
+    returnedConst (Returned (Const value)) = Just value
+    returnedConst _                        = Nothing
+
+    toNonConst Const{} = NonConst
+    toNonConst v       = v
+
+    uopToken UopMinus = "-"
+    uopToken op       = error (show op)
+
+
+linter :: AstActions (State [Text]) Text
+linter = astActions
+    { doNode = \file node act ->
+        case unFix node of
+            FunctionDefn _ (Fix (FunctionPrototype _ name _)) _ | isEligible name -> do
+                case returnedConstValues node of
+                  [v1, v2] -> warn file name $
+                      "function `" <> lexemeText name <> "` only ever returns two values `"
+                      <> v1 <> "` and `" <> v2 <> "`; it can return `bool`"
+                  _ -> return ()
+
+            _ -> act
+    }
+  where
+    -- Ignore event handlers named something with "handle" in the name.
+    isEligible = not . ("handle" `Text.isInfixOf`) . lexemeText
+
+analyse :: (FilePath, [Node (Lexeme Text)]) -> [Text]
+analyse = reverse . flip State.execState [] . traverseAst linter

--- a/src/Tokstyle/Linter/TypeCheck.hs
+++ b/src/Tokstyle/Linter/TypeCheck.hs
@@ -19,12 +19,11 @@ import           Data.Map.Strict              (Map)
 import qualified Data.Map.Strict              as Map
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
-import           Debug.Trace                  (trace)
 import           GHC.Stack                    (HasCallStack)
 import           Language.Cimple              (AssignOp (..), BinaryOp (..),
                                                Lexeme (..), LiteralType (..),
                                                Node, NodeF (..), UnaryOp (..))
-import           Language.Cimple.Diagnostics  (HasDiagnostics (..), warn)
+import           Language.Cimple.Diagnostics  (HasDiagnostics (..))
 import           Language.Cimple.TraverseAst  (AstActions, astActions, doNode,
                                                traverseAst)
 import           Text.PrettyPrint.ANSI.Leijen (Pretty (..), colon, int, text,

--- a/test/Tokstyle/Linter/BooleanReturnSpec.hs
+++ b/test/Tokstyle/Linter/BooleanReturnSpec.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Tokstyle.Linter.BooleanReturnSpec where
+
+import           Test.Hspec         (Spec, describe, it, shouldBe)
+
+import           Data.Text          (Text)
+import qualified Data.Text          as Text
+import           Language.Cimple    (Lexeme, Node)
+import           Language.Cimple.IO (parseText)
+import           Tokstyle.Linter    (allWarnings, analyse)
+
+
+mustParse :: MonadFail m => [Text] -> m [Node (Lexeme Text)]
+mustParse code =
+    case parseText $ Text.unlines code of
+        Left err -> fail err
+        Right ok -> return ok
+
+
+spec :: Spec
+spec =
+    describe "analyse" $ do
+        it "should give diagnostics on functions with only 2 const returns" $ do
+            ast <- mustParse
+                [ "int a(int b) {"
+                , "  return 1;"
+                , "  return 0;"
+                , "}"
+                ]
+            analyse allWarnings ("test.c", ast)
+                `shouldBe`
+                [ "test.c:1: function `a` only ever returns two values `0` and `1`; it can return `bool` [-Wboolean-return]"
+                ]
+
+        it "should show negative return values in the diagnostic" $ do
+            ast <- mustParse
+                [ "int a(int b) {"
+                , "  return -1;"
+                , "  return 0;"
+                , "}"
+                ]
+            analyse allWarnings ("test.c", ast)
+                `shouldBe`
+                [ "test.c:1: function `a` only ever returns two values `-1` and `0`; it can return `bool` [-Wboolean-return]"
+                ]
+
+        it "should not give diagnostics on functions with non-const returns" $ do
+            ast <- mustParse
+                [ "int a(int b) {"
+                , "  return 1;"
+                , "  return 0;"
+                , "  return foo();"
+                , "}"
+                ]
+            analyse allWarnings ("test.c", ast)
+                `shouldBe`
+                []
+
+        it "should not give diagnostics on functions with more than 2 const returns" $ do
+            ast <- mustParse
+                [ "int a(int b) {"
+                , "  return 1;"
+                , "  return 0;"
+                , "  return -1;"
+                , "}"
+                ]
+            analyse allWarnings ("test.c", ast)
+                `shouldBe`
+                []

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -22,6 +22,7 @@ library
   other-modules:
       Tokstyle.Common
     , Tokstyle.Linter.Booleans
+    , Tokstyle.Linter.BooleanReturn
     , Tokstyle.Linter.CallbackNames
     , Tokstyle.Linter.CallocArgs
     , Tokstyle.Linter.CallocType
@@ -121,6 +122,7 @@ test-suite testsuite
   other-modules:
       Tokstyle.LinterSpec
     , Tokstyle.Linter.BooleansSpec
+    , Tokstyle.Linter.BooleanReturnSpec
     , Tokstyle.Linter.ConstnessSpec
     , Tokstyle.Linter.TypeCheckSpec
     , Tokstyle.Linter.VarUnusedInScopeSpec


### PR DESCRIPTION
Functions that only return one of two constant values in any `return`
statement are effectively boolean functions but use `int` instead. This
linter warns about those functions. It ignores functions with `handle`
in the name because those may be callbacks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/153)
<!-- Reviewable:end -->
