### PR TITLE
fix: Fix `-Wdoc-comments` on functions with `non_null`.

### DIFF
--- a/src/Tokstyle/Linter/DocComments.hs
+++ b/src/Tokstyle/Linter/DocComments.hs
@@ -8,11 +8,10 @@ import           Control.Monad.State.Strict  (State)
 import qualified Control.Monad.State.Strict  as State
 import           Data.Fix                    (Fix (..))
 import           Data.Text                   (Text)
-import qualified Data.Text                   as Text
 import           Language.Cimple             (Lexeme (..), LexemeClass (..),
                                               Node, NodeF (..), removeSloc)
 import           Language.Cimple.Diagnostics (HasDiagnostics (..), warn)
-import           Language.Cimple.Pretty      (ppTranslationUnit)
+import           Language.Cimple.Pretty      (ppTranslationUnit, render)
 import           Language.Cimple.TraverseAst (AstActions, astActions, doNode,
                                               traverseAst)
 
@@ -29,28 +28,32 @@ instance HasDiagnostics Linter where
     addDiagnostic diag l@Linter{diags} = l{diags = addDiagnostic diag diags}
 
 
+-- | Extract the name of a function, possibly inside an attribute node.
+--
+-- Non-function nodes result in 'Nothing'.
+functionName :: Show a => Node (Lexeme a) -> Maybe a
+functionName (Fix (FunctionPrototype _ (L _ IdVar name) _)) = Just name
+functionName (Fix (FunctionDecl _ proto  )) = functionName proto
+functionName (Fix (FunctionDefn _ proto _)) = functionName proto
+functionName (Fix (AttrPrintf _ _ entity))  = functionName entity
+functionName (Fix (NonNull _ _ entity))     = functionName entity
+functionName _                              = Nothing
+
+
 linter :: AstActions (State Linter) Text
 linter = astActions
     { doNode = \file node act ->
         case unFix node of
-            Commented doc (Fix (FunctionDecl _ (Fix (FunctionPrototype _ (L _ IdVar fname) _)))) -> do
-                checkCommentEquals file doc fname
-
-            Commented doc (Fix (FunctionDefn _ (Fix (FunctionPrototype _ (L _ IdVar fname) _)) _)) -> do
-                checkCommentEquals file doc fname
-
-            {-
-            Commented _ n -> do
-                warn file node . Text.pack . show $ n
+            Commented doc entity -> do
+                case functionName entity of
+                  Nothing   -> return ()
+                  Just name -> checkCommentEquals file doc name
                 act
-            -}
 
             FunctionDefn{} -> return ()
             _ -> act
     }
   where
-    tshow = Text.pack . show
-
     checkCommentEquals file doc fname = do
         l@Linter{docs} <- State.get
         case lookup fname docs of
@@ -59,9 +62,9 @@ linter = astActions
             Just (file', doc') -> do
                 warn file doc $ "comment on definition of `" <> fname
                     <> "` does not match declaration:\n"
-                    <> tshow (ppTranslationUnit [doc])
+                    <> render (ppTranslationUnit [doc])
                 warn file' doc' $ "mismatching comment found here:\n"
-                    <> tshow (ppTranslationUnit [doc'])
+                    <> render (ppTranslationUnit [doc'])
 
 analyse :: [(FilePath, [Node (Lexeme Text)])] -> [Text]
 analyse = reverse . diags . flip State.execState empty . traverseAst linter . reverse


### PR DESCRIPTION
This diagnostic was completely ignored for most functions after we added
nullability annotations to everything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/170)
<!-- Reviewable:end -->
