### PR TITLE
test: Add a test to make sure arrays are treated as expected.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -30,6 +30,7 @@ haskell_library(
         hazel_library("microlens"),
         hazel_library("microlens-th"),
         hazel_library("mtl"),
+        hazel_library("parallel"),
         hazel_library("text"),
     ],
 )

--- a/src/Tokstyle/Linter.hs
+++ b/src/Tokstyle/Linter.hs
@@ -5,6 +5,7 @@ module Tokstyle.Linter
     , allWarnings
     ) where
 
+import           Control.Parallel.Strategies       (parMap, rpar)
 import           Data.Text                         (Text)
 import           Language.Cimple                   (Lexeme, Node)
 
@@ -44,7 +45,7 @@ type TranslationUnit = (FilePath, [Node (Lexeme Text)])
 
 run :: [(Text, t -> [Text])] -> [Text] -> t -> [Text]
 run linters flags tu =
-    concatMap apply $ filter ((`elem` flags) . fst) linters
+    concat . parMap rpar apply . filter ((`elem` flags) . fst) $ linters
   where
     apply (flag, f) = map (<> " [-W" <> flag <> "]") $ f tu
 

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -69,6 +69,7 @@ library
     , microlens
     , microlens-th
     , mtl
+    , parallel
     , text
 
 executable check-cimple

--- a/tools/check-cimple.hs
+++ b/tools/check-cimple.hs
@@ -45,9 +45,9 @@ parseArgs = first (processFlags . map (drop 2)) . partition ("-W" `isPrefixOf`)
 
 defaultFlags :: [String]
 defaultFlags =
-  [ "-Wno-callback-names"
-  , "-Wno-enum-names"
-  ]
+    [ "-Wno-callback-names"
+    , "-Wno-enum-names"
+    ]
 
 
 main :: IO ()


### PR DESCRIPTION
This was done correctly, but we hadn't documented why arrays are
ignored. Ignoring them causes false negatives, but the false positives
are somewhat difficult to avoid. See the tests for two cases in which we
don't want to reduce the scope of arrays but we would want to reduce the
scope of pointers (which are indistinguishable at the use-site).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/175)
<!-- Reviewable:end -->
