### PR TITLE
chore: Add some more tox_options functions to the exemptions.

### DIFF
--- a/src/Tokstyle/Linter/Callgraph.hs
+++ b/src/Tokstyle/Linter/Callgraph.hs
@@ -536,6 +536,7 @@ analyse = reverse . flip State.execState [] . linter . (builtins <>) . callgraph
         , "tox_options_get_local_discovery_enabled"
         , "tox_options_get_log_callback"
         , "tox_options_get_log_user_data"
+        , "tox_options_get_operating_system"
         , "tox_options_get_proxy_host"
         , "tox_options_get_proxy_port"
         , "tox_options_get_proxy_type"
@@ -548,6 +549,7 @@ analyse = reverse . flip State.execState [] . linter . (builtins <>) . callgraph
         , "tox_options_set_hole_punching_enabled"
         , "tox_options_set_ipv6_enabled"
         , "tox_options_set_local_discovery_enabled"
+        , "tox_options_set_operating_system"
         , "tox_options_set_proxy_type"
         , "tox_options_set_udp_enabled"
 


### PR DESCRIPTION
This should really be a pattern, but more so, those functions shouldn't
be hidden behind ugly ACCESSOR macros.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/182)
<!-- Reviewable:end -->
