### PR TITLE
chore: Add tox_private.h to the exemptions list for -Wdecls-have-defns.

### DIFF
--- a/src/Tokstyle/Linter/DeclsHaveDefns.hs
+++ b/src/Tokstyle/Linter/DeclsHaveDefns.hs
@@ -78,7 +78,7 @@ analyse =
     . Map.elems
     . flip State.execState empty
     . traverseAst collectPairs
-    . filter (not . (`elem` ["ccompat.h", "tox.h"]) . takeFileName . fst)
+    . filter (not . (`elem` ["tox.h", "tox_private.h"]) . takeFileName . fst)
   where
     lacksDefn DeclDefn{decl, defn = Nothing} = decl
     lacksDefn _                              = Nothing


### PR DESCRIPTION
Because implementations are provided by `CONST_FUNCTION` and friends,
which tokstyle has no clue about.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/184)
<!-- Reviewable:end -->
