### PR TITLE
fix: Disallow `sizeof(MyStruct*)` with 1 exemption.

### DIFF
--- a/tools/check-c.hs
+++ b/tools/check-c.hs
@@ -214,7 +214,7 @@ checkCast _ _ e = error (show e)
 -- | This catches `sizeof(buf)` where `buf` is a pointer instead of an array.
 checkSizeof :: MonadTrav m => CExpr -> Type -> m ()
 checkSizeof _ (canonicalType -> TY_struct _) = return ()
-checkSizeof _ (canonicalType -> TY_struct_ptr _) = return ()
+checkSizeof _ (canonicalType -> TY_struct_ptr "IPPTsPng") = return ()
 checkSizeof _ ArrayType{} = return ()
 checkSizeof e ty
   | isIntegral ty = return ()


### PR DESCRIPTION
This can be a hard to discover bug and compilers don't warn about it.

The one exemption is used in a loop. Maybe that shouldn't be done, but
I'll look into that later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/185)
<!-- Reviewable:end -->
