### PR TITLE
fix: Disable VLA support to catch more errors.

### DIFF
--- a/tools/check-c.hs
+++ b/tools/check-c.hs
@@ -399,6 +399,8 @@ defaultCppOpts :: String -> [String]
 defaultCppOpts sysInclude =
     [ "-nostdinc"
     , "-undef"
+    , "-DDISABLE_VLA=1"
+    , "-D__COMPCERT__=1"
     , "-D__LITTLE_ENDIAN=0x4321"
     , "-D__BYTE_ORDER=__LITTLE_ENDIAN"
     , "-I" <> sysInclude


### PR DESCRIPTION
This will catch `sizeof(my_vla)`, which doesn't work on systems like
Windows where we don't use VLAs and instead use alloca.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/186)
<!-- Reviewable:end -->
