### PR TITLE
fix: Add exemption for in `-Wparens` for `if ((x))`.

### DIFF
--- a/src/Tokstyle/Linter/Parens.hs
+++ b/src/Tokstyle/Linter/Parens.hs
@@ -6,6 +6,7 @@ module Tokstyle.Linter.Parens (analyse) where
 import           Control.Monad.State.Strict  (State)
 import qualified Control.Monad.State.Strict  as State
 import           Data.Fix                    (Fix (..))
+import           Data.Maybe                  (maybeToList)
 import           Data.Text                   (Text)
 import           Language.Cimple             (Lexeme (..), Node, NodeF (..))
 import           Language.Cimple.Diagnostics (warn)
@@ -38,6 +39,9 @@ linter = astActions
             FunctionCall _ args -> do
                 mapM_ (checkArg file) args
                 act
+
+            IfStmt (Fix (ParenExpr c)) t e ->
+                traverseAst linter (file, [c, t] ++ maybeToList e)
 
             Return (Just (Fix ParenExpr{})) -> do
                 warn file node "return expression does not need parentheses"

--- a/test/Tokstyle/Linter/ParensSpec.hs
+++ b/test/Tokstyle/Linter/ParensSpec.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Tokstyle.Linter.ParensSpec where
+
+import           Test.Hspec          (Spec, it, shouldBe)
+
+import           Tokstyle.Linter     (allWarnings, analyse)
+import           Tokstyle.LinterSpec (mustParse)
+
+
+spec :: Spec
+spec = do
+    it "warns about parentheses around return expressions" $ do
+        ast <- mustParse
+            [ "int a(int b) {"
+            , "  return (1 + 2);"
+            , "}"
+            ]
+        analyse allWarnings ("test.c", ast)
+            `shouldBe`
+            [ "test.c:2: return expression does not need parentheses [-Wparens]"
+            ]
+
+    it "does not warn about parens in if conditions" $ do
+        ast <- mustParse
+            [ "int a(int b) {"
+            , "  if ((true)) { return 3; }"
+            , "}"
+            ]
+        analyse allWarnings ("test.c", ast) `shouldBe` []

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -135,6 +135,7 @@ test-suite testsuite
     , Tokstyle.Linter.CallocTypeSpec
     , Tokstyle.Linter.CompoundInitSpec
     , Tokstyle.Linter.ConstnessSpec
+    , Tokstyle.Linter.ParensSpec
     , Tokstyle.Linter.SwitchIfSpec
     , Tokstyle.Linter.TypeCheckSpec
     , Tokstyle.Linter.VarUnusedInScopeSpec


### PR DESCRIPTION
This is used to silence warnings about constant if statements like:
```
if ((true)) {
    return 2;
}

return 3;
```

Example: https://github.com/TokTok/c-toxcore/pull/2234

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/191)
<!-- Reviewable:end -->
