### PR TITLE
fix: Allow up to 2 if-branches to not be a switch.

### DIFF
--- a/src/Tokstyle/Linter/SwitchIf.hs
+++ b/src/Tokstyle/Linter/SwitchIf.hs
@@ -43,13 +43,13 @@ collectInfo e =
     IfInfo (Just []) [e]
 
 
--- | Returns 'True' if there are at least 2 if conditions comparing a variable
+-- | Returns 'True' if there are at least 3 if conditions comparing a variable
 -- to a constant and all variable names are the same. Additionally checks
 -- whether all branches are single statements, in which case it returns
 -- 'False'.
 shouldDiagnose :: [Lexeme Text] -> [Node (Lexeme Text)] -> Bool
 shouldDiagnose cs branches =
-    length cs >= 2 && length (nub $ map lexemeText cs) == 1 && not (all singleStatement branches)
+    length cs >= 3 && length (nub $ map lexemeText cs) == 1 && not (all singleStatement branches)
   where
     singleStatement (Fix (CompoundStmt [_])) = True
     singleStatement _                        = False

--- a/test/Tokstyle/Linter/SwitchIfSpec.hs
+++ b/test/Tokstyle/Linter/SwitchIfSpec.hs
@@ -22,6 +22,22 @@ spec = do
             ]
         analyse ["switch-if"] ("test.c", ast) `shouldBe` []
 
+    it "accepts a if/else with only 2 comparisons" $ do
+        ast <- mustParse
+            [ "bool a(int b) {"
+            , "  if (b == THE_FOO) {"
+            , "    print_int(b);"
+            , "    return true;"
+            , "  } else if (b == THE_BAR) {"
+            , "    print_int(b);"
+            , "    return true;"
+            , "  } else {"
+            , "    return false;"
+            , "  }"
+            , "}"
+            ]
+        analyse ["switch-if"] ("test.c", ast) `shouldBe` []
+
     it "ignores candidates where all branches are single statements" $ do
         ast <- mustParse
             [ "int a(int b) {"
@@ -29,6 +45,8 @@ spec = do
             , "    return 0;"
             , "  } else if (b == THE_BAR) {"
             , "    return 1;"
+            , "  } else if (b == THE_BAZ) {"
+            , "    return 2;"
             , "  }"
             , "}"
             ]
@@ -42,6 +60,8 @@ spec = do
             , "    return 0;"
             , "  } else if (b == THE_BAR) {"
             , "    return 1;"
+            , "  } else if (b == THE_BAZ) {"
+            , "    return 2;"
             , "  }"
             , "}"
             ]
@@ -58,8 +78,10 @@ spec = do
             , "    return 0;"
             , "  } else if (b == THE_BAR) {"
             , "    return 1;"
-            , "  } else {"
+            , "  } else if (b == THE_BAZ) {"
             , "    return 2;"
+            , "  } else {"
+            , "    return 3;"
             , "  }"
             , "}"
             ]
@@ -77,8 +99,10 @@ spec = do
             , "      return 0;"
             , "    } else if (b == THE_BAR) {"
             , "      return 1;"
-            , "    } else {"
+            , "    } else if (b == THE_BAZ) {"
             , "      return 2;"
+            , "    } else {"
+            , "      return 3;"
             , "    }"
             , "  }"
             , "}"
@@ -99,8 +123,10 @@ spec = do
             , "      return 0;"
             , "    } else if (b == THE_BAR) {"
             , "      return 1;"
-            , "    } else {"
+            , "    } else if (b == THE_BAZ) {"
             , "      return 2;"
+            , "    } else {"
+            , "      return 3;"
             , "    }"
             , "  }"
             , "}"
@@ -118,6 +144,8 @@ spec = do
             , "    return 0;"
             , "  } else if (c == THE_BAR) {"
             , "    return 1;"
+            , "  } else if (c == THE_BAZ) {"
+            , "    return 2;"
             , "  } else {"
             , "    return 2;"
             , "  }"


### PR DESCRIPTION
A `switch` starts to improve readability when there are many branches
comparing a variable to different enum constants. For 2 branches, we'll
leave it up to the programmer to decide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/192)
<!-- Reviewable:end -->
