### PR TITLE
fix: add shared_key_is_empty(...) to pure functions

### DIFF
--- a/src/Tokstyle/Linter/Assert.hs
+++ b/src/Tokstyle/Linter/Assert.hs
@@ -47,6 +47,7 @@ checkAssertArg file name expr =
     exemptions =
         [ "make_family"
         , "memcmp"
+        , "shared_key_is_empty"
         ]
 
 


### PR DESCRIPTION
This prevents a warning because it's used in an assert in [#2317](https://github.com/TokTok/c-toxcore/pull/2317)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-tokstyle/196)
<!-- Reviewable:end -->
