### PR TITLE
chore: Update dockerfile documentation to ubuntu 22.04.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Using the built docker image (only contains binaries, so you need an OS around i
 
 ```dockerfile
 FROM toxchat/haskell:hs-tokstyle AS tokstyle
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 COPY --from=tokstyle /bin/check-cimple /bin/
 WORKDIR /work


### PR DESCRIPTION
This is the version we use in most of our docker images now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/200)
<!-- Reviewable:end -->
