### PR TITLE
chore: Fix ansi-wl-pprint dependency at 0.6.9.

### DIFF
--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -57,7 +57,7 @@ library
   build-depends:
       base              >= 4 && < 5
     , aeson             >= 0.8.1.0
-    , ansi-wl-pprint
+    , ansi-wl-pprint    <= 0.6.9
     , array
     , bytestring
     , cimple            >= 0.0.17


### PR DESCRIPTION
Their API broke in 1.0.2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/202)
<!-- Reviewable:end -->
