### PR TITLE
fix: Allow implicit conversions to `const void *`.

### DIFF
--- a/tools/check-c.hs
+++ b/tools/check-c.hs
@@ -78,6 +78,7 @@ checkConversion context (l, removeQuals -> lTy) (r, removeQuals -> rTy) =
       ("vpx_codec_er_flags_t", "int") -> return ()
       ("bool", "int") | relaxed r     -> return ()
       ("void *", _)                   -> return ()
+      ("const void *", _)             -> return ()
 
       -- int literals.
       ("uint32_t","int")              -> return ()


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/203)
<!-- Reviewable:end -->
