### PR TITLE
fix: Add `randombytes` to exemptions list for charptr cast.

### DIFF
--- a/test/Tokstyle/LinterSpec.hs
+++ b/test/Tokstyle/LinterSpec.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Tokstyle.LinterSpec (mustParse, spec) where
 

--- a/tools/check-c.hs
+++ b/tools/check-c.hs
@@ -320,7 +320,7 @@ checkExpr cast@(CCast t e _) = do
     exprTy <- tExpr [] RValue e
     Env{ctx} <- getUserState
     -- Some exemptions where weird casts like int* -> char* may happen.
-    unless (head ctx `elem` ["call:getsockopt", "call:setsockopt", "call:bs_list_add", "call:bs_list_remove", "call:bs_list_find", "call:random_bytes"]) $
+    unless (head ctx `elem` ["call:getsockopt", "call:setsockopt", "call:bs_list_add", "call:bs_list_remove", "call:bs_list_find", "call:random_bytes", "call:randombytes"]) $
         checkCast castTy exprTy e
     checkDecl t
     checkExpr e


### PR DESCRIPTION
zoff wants to use it in toxav.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/205)
<!-- Reviewable:end -->
