### PR TITLE
refactor: Use `parseProgram` instead of `parseFiles`.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,8 +2,6 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_library")
 load("//third_party/haskell/hspec-discover:build_defs.bzl", "hspec_test")
 load("//tools/project:build_defs.bzl", "project")
 
-package(features = ["-layering_check"])
-
 project()
 
 haskell_library(

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -17,9 +17,9 @@ source-repository head
 
 library
   default-language: Haskell2010
-  exposed-modules:  Tokstyle.Linter
-  other-modules:
+  exposed-modules:
     Tokstyle.Common
+    Tokstyle.Linter
     Tokstyle.Linter.Assert
     Tokstyle.Linter.BooleanReturn
     Tokstyle.Linter.Booleans
@@ -54,23 +54,23 @@ library
   ghc-options:      -Wall
   hs-source-dirs:   src
   build-depends:
-      aeson           >=0.8.1.0
+      aeson           >=0.8.1.0 && <3
     , ansi-wl-pprint  <0.6.9.0
-    , array
+    , array           <0.6
     , base            >=4       && <5
-    , bytestring
+    , bytestring      <0.13
     , cimple          >=0.0.17
-    , containers
-    , data-fix
-    , deepseq
-    , edit-distance
-    , filepath
-    , groom
-    , microlens
-    , microlens-th
-    , mtl
-    , parallel
-    , text
+    , containers      <0.8
+    , data-fix        <0.4
+    , deepseq         <2
+    , edit-distance   <0.3
+    , filepath        <2
+    , groom           <0.2
+    , microlens       <0.5
+    , microlens-th    <0.5
+    , mtl             <3
+    , parallel        <4
+    , text            <3
 
 executable check-cimple
   default-language: Haskell2010
@@ -80,9 +80,9 @@ executable check-cimple
   build-depends:
       base      <5
     , cimple
-    , parallel
+    , parallel  <4
     , text
-    , time
+    , time      <2
     , tokstyle
 
 executable check-c
@@ -93,8 +93,8 @@ executable check-c
   build-depends:
       base            <5
     , containers
-    , language-c
-    , monad-parallel
+    , language-c      <0.10
+    , monad-parallel  <0.9
 
 executable webservice
   main-is:          webservice.hs
@@ -110,10 +110,10 @@ executable webservice
     , servant-server  >=0.5
     , text
     , tokstyle
-    , wai
-    , wai-cors
-    , wai-extra
-    , warp
+    , wai             <4
+    , wai-cors        <0.3
+    , wai-extra       <4
+    , warp            <4
 
 test-suite testsuite
   type:               exitcode-stdio-1.0
@@ -138,6 +138,6 @@ test-suite testsuite
   build-depends:
       base      <5
     , cimple
-    , hspec
+    , hspec     <3
     , text
     , tokstyle

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,7 +1,5 @@
 load("@rules_haskell//haskell:defs.bzl", "haskell_binary")
 
-package(features = ["-layering_check"])
-
 haskell_binary(
     name = "check-cimple",
     srcs = ["check-cimple.hs"],

--- a/tools/check-cimple.hs
+++ b/tools/check-cimple.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
-import           Control.Arrow               (first)
+import           Control.Arrow               (first, second)
 import           Control.Parallel.Strategies (parMap, rpar)
 import           Data.List                   (isPrefixOf, partition)
 import           Data.Text                   (Text)
@@ -11,7 +11,8 @@ import qualified Data.Text.IO                as Text
 import           Data.Time.Clock             (UTCTime, diffUTCTime,
                                               getCurrentTime)
 import           Language.Cimple             (Lexeme, Node)
-import           Language.Cimple.IO          (parseFiles)
+import           Language.Cimple.IO          (parseProgram)
+import qualified Language.Cimple.Program     as Program
 import           System.Environment          (getArgs)
 import           System.IO                   (hPutStrLn, stderr)
 
@@ -55,7 +56,7 @@ main = do
     (flags, files) <- parseArgs . (defaultFlags ++) <$> getArgs
     start <- getCurrentTime
     hPutStrLn stderr $ "Parsing " <> show (length files) <> " files..."
-    parseFiles files >>= getRight start >>= processAst flags
+    parseProgram files >>= getRight start >>= (processAst flags . second Program.toList)
 
 getRight :: UTCTime -> Either String a -> IO (UTCTime, a)
 getRight _ (Left err) = putStrLn err >> fail "aborting after parse error"

--- a/web/BUILD.bazel
+++ b/web/BUILD.bazel
@@ -1,7 +1,5 @@
 load("@rules_haskell//haskell:defs.bzl", "haskell_binary")
 
-package(features = ["-layering_check"])
-
 haskell_binary(
     name = "webservice",
     srcs = glob(["**/*.hs"]),


### PR DESCRIPTION
The former does additional include checking and normalisation, needed for module dependency checks. We'll change parseFiles to not do that, so we can use it for apigen.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/207)
<!-- Reviewable:end -->
