### PR TITLE
fix: Allow `a?b:c` in assert.

### DIFF
--- a/src/Tokstyle/Linter/Assert.hs
+++ b/src/Tokstyle/Linter/Assert.hs
@@ -33,6 +33,10 @@ checkAssertArg file name expr =
       BinaryExpr lhs _ rhs -> do
           checkAssertArg file name lhs
           checkAssertArg file name rhs
+      TernaryExpr cond thenB elseB -> do
+          checkAssertArg file name cond
+          checkAssertArg file name thenB
+          checkAssertArg file name elseB
       FunctionCall _ [] -> return ()  -- no arguments = constant function
       FunctionCall (Fix (VarExpr (L _ _ func))) args -> do
           mapM_ (checkAssertArg file name) args

--- a/src/Tokstyle/Linter/TypeCheck.hs
+++ b/src/Tokstyle/Linter/TypeCheck.hs
@@ -18,7 +18,7 @@ import           Data.Map.Strict              (Map)
 import qualified Data.Map.Strict              as Map
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
-import           Debug.Trace                  (trace)
+--import           Debug.Trace                  (trace)
 import           GHC.Stack                    (HasCallStack)
 import           Language.Cimple              (AssignOp (..), BinaryOp (..),
                                                Lexeme (..), LiteralType (..),
@@ -173,7 +173,7 @@ addName n ty = do
 
 getName :: HasCallStack => Text -> State Env Type
 getName n = do
-    trace ("g " <> show n) $ return ()
+--    trace ("g " <> show n) $ return ()
     found <- Map.lookup n . envTypes <$> State.get
     case found of
       Just ok -> return ok


### PR DESCRIPTION
If condition and both branches are pure, then the ternary expression is pure as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/208)
<!-- Reviewable:end -->
