### PR TITLE
feat: Check that enum `from_int` functions are correct.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -22,6 +22,7 @@ haskell_library(
         "//third_party/haskell:data-fix",
         "//third_party/haskell:deepseq",
         "//third_party/haskell:edit-distance",
+        "//third_party/haskell:extra",
         "//third_party/haskell:filepath",
         "//third_party/haskell:groom",
         "//third_party/haskell:microlens",

--- a/src/Tokstyle/Common.hs
+++ b/src/Tokstyle/Common.hs
@@ -1,12 +1,15 @@
 {-# LANGUAGE Strict     #-}
 {-# LANGUAGE StrictData #-}
 module Tokstyle.Common
-    ( isPointer
+    ( functionName
+    , isPointer
+    , semEq
     ) where
 
 import           Data.Fix        (Fix (..))
 import           Data.Text       (Text)
-import           Language.Cimple (Lexeme (..), Node, NodeF (..))
+import           Language.Cimple (Lexeme (..), LexemeClass (..), Node,
+                                  NodeF (..), removeSloc)
 
 
 isPointer :: Node (Lexeme Text) -> Bool
@@ -19,3 +22,20 @@ isPointer x = case unFix x of
     TyStruct{}      -> False
     TyUserDefined{} -> False
     _               -> error $ show x
+
+
+-- | Extract the name of a function, possibly inside an attribute node.
+--
+-- Non-function nodes result in 'Nothing'.
+functionName :: Show a => Node (Lexeme a) -> Maybe a
+functionName (Fix (FunctionPrototype _ (L _ IdVar name) _)) = Just name
+functionName (Fix (FunctionDecl _ proto  )) = functionName proto
+functionName (Fix (FunctionDefn _ proto _)) = functionName proto
+functionName (Fix (AttrPrintf _ _ entity))  = functionName entity
+functionName (Fix (NonNull _ _ entity))     = functionName entity
+functionName _                              = Nothing
+
+
+-- Semantic equality: nodes are the same, except for source locations.
+semEq :: Node (Lexeme Text) -> Node (Lexeme Text) -> Bool
+semEq a b = removeSloc a == removeSloc b

--- a/src/Tokstyle/Common.hs
+++ b/src/Tokstyle/Common.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE Strict     #-}
-{-# LANGUAGE StrictData #-}
+{-# LANGUAGE Strict #-}
 module Tokstyle.Common
     ( functionName
     , isPointer

--- a/src/Tokstyle/Linter/Assert.hs
+++ b/src/Tokstyle/Linter/Assert.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.Assert (analyse) where
 
 import           Control.Monad               (unless)

--- a/src/Tokstyle/Linter/BooleanReturn.hs
+++ b/src/Tokstyle/Linter/BooleanReturn.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.BooleanReturn where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/Booleans.hs
+++ b/src/Tokstyle/Linter/Booleans.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms   #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.Booleans (analyse) where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/CallbackNames.hs
+++ b/src/Tokstyle/Linter/CallbackNames.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.CallbackNames (analyse) where
 
 import           Control.Monad               (unless)

--- a/src/Tokstyle/Linter/Callgraph.hs
+++ b/src/Tokstyle/Linter/Callgraph.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 {-# LANGUAGE TupleSections     #-}
 {-# OPTIONS_GHC -Wwarn #-}
 module Tokstyle.Linter.Callgraph where

--- a/src/Tokstyle/Linter/CallocArgs.hs
+++ b/src/Tokstyle/Linter/CallocArgs.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms   #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.CallocArgs (analyse) where
 
 import           Control.Monad.State.Strict  (State)
@@ -49,9 +48,9 @@ linter = astActions
             checkNmemb funName file nmemb
             checkSize funName file size
 
-        Calloc "mem_alloc"    _ -> warn file node $ "invalid `mem_alloc` invocation: 1 arguments after `mem` expected"
-        Calloc "mem_valloc"   _ -> warn file node $ "invalid `mem_valloc` invocation: 2 arguments after `mem` expected"
-        Calloc "mem_vrealloc" _ -> warn file node $ "invalid `mem_vrealloc` invocation: 3 argument after `mem` expected"
+        Calloc "mem_alloc"    _ -> warn file node "invalid `mem_alloc` invocation: 1 arguments after `mem` expected"
+        Calloc "mem_valloc"   _ -> warn file node "invalid `mem_valloc` invocation: 2 arguments after `mem` expected"
+        Calloc "mem_vrealloc" _ -> warn file node "invalid `mem_vrealloc` invocation: 3 argument after `mem` expected"
 
         _ -> act
     }

--- a/src/Tokstyle/Linter/CallocType.hs
+++ b/src/Tokstyle/Linter/CallocType.hs
@@ -9,12 +9,12 @@ import qualified Control.Monad.State.Strict  as State
 import           Data.Fix                    (Fix (..))
 import           Data.Text                   (Text)
 import qualified Data.Text                   as Text
-import           Language.Cimple             (Lexeme (..), Node, NodeF (..),
-                                              removeSloc)
+import           Language.Cimple             (Lexeme (..), Node, NodeF (..))
 import           Language.Cimple.Diagnostics (warn)
 import           Language.Cimple.Pretty      (showNode)
 import           Language.Cimple.TraverseAst (AstActions, astActions, doNode,
                                               traverseAst)
+import           Tokstyle.Common             (semEq)
 
 
 checkTypes :: Text -> FilePath -> Node (Lexeme Text) -> Node (Lexeme Text) -> State [Text] ()
@@ -23,7 +23,7 @@ checkTypes funName file castTy sizeofTy = case unFix castTy of
         warn file castTy $
             "`" <> funName <> "` should not be used for `" <> showNode castTy
             <> "`; use `mem_balloc` instead"
-    TyPointer ty1 | removeSloc ty1 == removeSloc sizeofTy -> return ()
+    TyPointer ty1 | ty1 `semEq` sizeofTy -> return ()
     _ -> warn file castTy $
         "`" <> funName <> "` result is cast to `" <> showNode castTy
         <> "` but allocated type is `" <> showNode sizeofTy <> "`"

--- a/src/Tokstyle/Linter/CallocType.hs
+++ b/src/Tokstyle/Linter/CallocType.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms   #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.CallocType (analyse) where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/CompoundInit.hs
+++ b/src/Tokstyle/Linter/CompoundInit.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.CompoundInit (analyse) where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/Constness.hs
+++ b/src/Tokstyle/Linter/Constness.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.Constness where
 
 import           Control.Applicative         ((<|>))

--- a/src/Tokstyle/Linter/DeclaredOnce.hs
+++ b/src/Tokstyle/Linter/DeclaredOnce.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.DeclaredOnce (analyse) where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/DeclsHaveDefns.hs
+++ b/src/Tokstyle/Linter/DeclsHaveDefns.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.DeclsHaveDefns (analyse) where
 
 import           Control.Arrow               ((&&&))

--- a/src/Tokstyle/Linter/DocComments.hs
+++ b/src/Tokstyle/Linter/DocComments.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.DocComments (analyse) where
 
 import           Control.Monad               (forM_)

--- a/src/Tokstyle/Linter/DocComments.hs
+++ b/src/Tokstyle/Linter/DocComments.hs
@@ -9,12 +9,12 @@ import           Control.Monad.State.Strict  (State)
 import qualified Control.Monad.State.Strict  as State
 import           Data.Fix                    (Fix (..))
 import           Data.Text                   (Text)
-import           Language.Cimple             (Lexeme (..), LexemeClass (..),
-                                              Node, NodeF (..), removeSloc)
+import           Language.Cimple             (Lexeme (..), Node, NodeF (..))
 import           Language.Cimple.Diagnostics (HasDiagnostics (..), warn)
 import           Language.Cimple.Pretty      (ppTranslationUnit, render)
 import           Language.Cimple.TraverseAst (AstActions, astActions, doNode,
                                               traverseAst)
+import           Tokstyle.Common             (functionName, semEq)
 
 
 data Linter = Linter
@@ -27,18 +27,6 @@ empty = Linter [] []
 
 instance HasDiagnostics Linter where
     addDiagnostic diag l@Linter{diags} = l{diags = addDiagnostic diag diags}
-
-
--- | Extract the name of a function, possibly inside an attribute node.
---
--- Non-function nodes result in 'Nothing'.
-functionName :: Show a => Node (Lexeme a) -> Maybe a
-functionName (Fix (FunctionPrototype _ (L _ IdVar name) _)) = Just name
-functionName (Fix (FunctionDecl _ proto  )) = functionName proto
-functionName (Fix (FunctionDefn _ proto _)) = functionName proto
-functionName (Fix (AttrPrintf _ _ entity))  = functionName entity
-functionName (Fix (NonNull _ _ entity))     = functionName entity
-functionName _                              = Nothing
 
 
 linter :: AstActions (State Linter) Text
@@ -58,7 +46,7 @@ linter = astActions
         l@Linter{docs} <- State.get
         case lookup fname docs of
             Nothing -> State.put l{docs = (fname, (file, doc)):docs}
-            Just (_, doc') | removeSloc doc == removeSloc doc' -> return ()
+            Just (_, doc') | semEq doc doc' -> return ()
             Just (file', doc') -> do
                 warn file doc $ "comment on definition of `" <> fname
                     <> "` does not match declaration:\n"

--- a/src/Tokstyle/Linter/EnumNames.hs
+++ b/src/Tokstyle/Linter/EnumNames.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.EnumNames (analyse) where
 
 import           Control.Monad               (unless)

--- a/src/Tokstyle/Linter/FuncPrototypes.hs
+++ b/src/Tokstyle/Linter/FuncPrototypes.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.FuncPrototypes (analyse) where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/FuncScopes.hs
+++ b/src/Tokstyle/Linter/FuncScopes.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.FuncScopes (analyse) where
 
 import           Control.Monad               (when)

--- a/src/Tokstyle/Linter/GlobalFuncs.hs
+++ b/src/Tokstyle/Linter/GlobalFuncs.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.GlobalFuncs (analyse) where
 
 import qualified Control.Monad.State.Strict  as State

--- a/src/Tokstyle/Linter/LargeStructParams.hs
+++ b/src/Tokstyle/Linter/LargeStructParams.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.LargeStructParams (analyse) where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/LoggerCalls.hs
+++ b/src/Tokstyle/Linter/LoggerCalls.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.LoggerCalls (analyse) where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/LoggerConst.hs
+++ b/src/Tokstyle/Linter/LoggerConst.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.LoggerConst (analyse) where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/LoggerNoEscapes.hs
+++ b/src/Tokstyle/Linter/LoggerNoEscapes.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.LoggerNoEscapes (analyse) where
 
 import           Control.Monad               (when)

--- a/src/Tokstyle/Linter/MallocType.hs
+++ b/src/Tokstyle/Linter/MallocType.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.MallocType (analyse) where
 
 import           Control.Monad               (unless)

--- a/src/Tokstyle/Linter/MemcpyStructs.hs
+++ b/src/Tokstyle/Linter/MemcpyStructs.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.MemcpyStructs (analyse) where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/MissingNonNull.hs
+++ b/src/Tokstyle/Linter/MissingNonNull.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.MissingNonNull (analyse) where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/NonNull.hs
+++ b/src/Tokstyle/Linter/NonNull.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 {-# LANGUAGE ViewPatterns      #-}
 module Tokstyle.Linter.NonNull (analyse) where
 

--- a/src/Tokstyle/Linter/Parens.hs
+++ b/src/Tokstyle/Linter/Parens.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.Parens (analyse) where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/SwitchIf.hs
+++ b/src/Tokstyle/Linter/SwitchIf.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms   #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.SwitchIf (analyse) where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/TypeCheck.hs
+++ b/src/Tokstyle/Linter/TypeCheck.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 {-# LANGUAGE TupleSections     #-}
 module Tokstyle.Linter.TypeCheck where
 

--- a/src/Tokstyle/Linter/TypedefName.hs
+++ b/src/Tokstyle/Linter/TypedefName.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.Linter.TypedefName where
 
 import           Control.Monad.State.Strict  (State)

--- a/src/Tokstyle/Linter/UnsafeFunc.hs
+++ b/src/Tokstyle/Linter/UnsafeFunc.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 {-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE ViewPatterns      #-}
 module Tokstyle.Linter.UnsafeFunc (analyse) where

--- a/src/Tokstyle/Linter/VarUnusedInScope.hs
+++ b/src/Tokstyle/Linter/VarUnusedInScope.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes        #-}
-{-# LANGUAGE StrictData        #-}
+{-# LANGUAGE Strict            #-}
 {-# LANGUAGE TemplateHaskell   #-}
 module Tokstyle.Linter.VarUnusedInScope (analyse) where
 

--- a/src/Tokstyle/SemFmt/EnumFromInt.hs
+++ b/src/Tokstyle/SemFmt/EnumFromInt.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict            #-}
+{-# LANGUAGE StrictData        #-}
+module Tokstyle.SemFmt.EnumFromInt (analyse) where
+
+import           Control.Applicative         ((<|>))
+import           Control.Monad               (unless)
+import           Control.Monad.State.Strict  (State)
+import qualified Control.Monad.State.Strict  as State
+import           Data.Fix                    (Fix (..))
+import           Data.List.Extra             (firstJust)
+import           Data.Maybe                  (mapMaybe)
+import           Data.Text                   (Text)
+import qualified Data.Text                   as Text
+import           Language.Cimple             (Lexeme (..), LiteralType (..),
+                                              Node, NodeF (..))
+import           Language.Cimple.Diagnostics (HasDiagnostics (..), warn)
+import           Language.Cimple.Pretty      (ppTranslationUnit, render)
+import           Language.Cimple.TraverseAst (AstActions, astActions, doNode,
+                                              traverseAst)
+import           Tokstyle.Common             (semEq)
+
+
+data Linter = Linter
+    { diags :: [Text]
+    , enums :: [(Text, [Node (Lexeme Text)])]
+    }
+
+instance HasDiagnostics Linter where
+    addDiagnostic diag l@Linter{diags} = l{diags = addDiagnostic diag diags}
+
+empty :: Linter
+empty = Linter [] []
+
+funSuffix :: Text
+funSuffix = "_from_int"
+
+mkFunBody :: Lexeme Text -> [Node (Lexeme Text)] -> Maybe (Node (Lexeme Text))
+mkFunBody varName enumrs = do
+    dn <- defaultName
+    let defaultCase = Fix (Default (Fix (Return (Just (Fix (LiteralExpr ConstId dn))))))
+    return $ Fix (CompoundStmt
+        [Fix (SwitchStmt (Fix (VarExpr varName)) (mapMaybe mkCase enumrs ++ [defaultCase]))])
+  where
+    defaultName =
+        firstJust isDefault enumrs <|> firstJust isEnumr enumrs
+    isDefault (Fix (Enumerator l@(L _ _ name) _))
+        | "_INVALID" `Text.isSuffixOf` name = Just l
+    isDefault _ = Nothing
+    isEnumr (Fix (Enumerator l _)) = Just l
+    isEnumr _                      = Nothing
+
+    mkCase (Fix Comment{}) = Nothing
+    mkCase (Fix (Enumerator name _)) = Just $
+        -- case $name: return $name;
+        Fix (Case (Fix (LiteralExpr ConstId name))
+             (Fix (Return (Just (Fix (LiteralExpr ConstId name))))))
+    mkCase node = error $ show node
+
+
+collectEnums :: AstActions (State Linter) Text
+collectEnums = astActions
+    { doNode = \file node act ->
+        case unFix node of
+            EnumDecl (L _ _ ename) enumrs _ -> do
+                l@Linter{enums} <- State.get
+                case lookup ename enums of
+                    Nothing -> State.put l{enums = (Text.toLower ename, enumrs):enums}
+                    Just{} -> warn file node $ "duplicate enum: " <> ename
+
+            _ -> act
+    }
+
+linter :: AstActions (State Linter) Text
+linter = astActions
+    { doNode = \file node act ->
+        case unFix node of
+            FunctionDefn _ (Fix (FunctionPrototype _ (L _ _ fname) [Fix (VarDecl _ varName _)])) body
+                | funSuffix `Text.isSuffixOf` fname -> do
+                Linter{enums} <- State.get
+                case lookup (Text.dropEnd (Text.length funSuffix) fname) enums of
+                    Nothing -> warn file node $ "enum not found for function: " <> fname
+                    Just enumrs -> do
+                        case mkFunBody varName enumrs of
+                            Nothing ->
+                                warn file node $ "invalid enum format for " <> fname
+                            Just wanted ->
+                                unless (body `semEq` wanted) $
+                                    warn file node $ "enum from_int function should be:\n"
+                                        <> render (ppTranslationUnit [wanted])
+
+            _ -> act
+    }
+
+analyse :: [(FilePath, [Node (Lexeme Text)])] -> [Text]
+analyse = reverse . diags . flip State.execState empty . (\tus -> traverseAst collectEnums tus >> traverseAst linter tus) . reverse

--- a/src/Tokstyle/SemFmt/EnumFromInt.hs
+++ b/src/Tokstyle/SemFmt/EnumFromInt.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Strict            #-}
-{-# LANGUAGE StrictData        #-}
 module Tokstyle.SemFmt.EnumFromInt (analyse) where
 
 import           Control.Applicative         ((<|>))

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@
 packages: [.]
 resolver: lts-21.9
 extra-deps:
-  - cimple-0.0.17
+  - cimple-0.0.18

--- a/test/Tokstyle/Linter/BooleanReturnSpec.hs
+++ b/test/Tokstyle/Linter/BooleanReturnSpec.hs
@@ -3,7 +3,7 @@ module Tokstyle.Linter.BooleanReturnSpec where
 
 import           Test.Hspec          (Spec, it, shouldBe)
 
-import           Tokstyle.Linter     (allWarnings, analyse)
+import           Tokstyle.Linter     (allWarnings, analyseLocal)
 import           Tokstyle.LinterSpec (mustParse)
 
 
@@ -16,7 +16,7 @@ spec = do
             , "  return 0;"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:1: function `a` only ever returns two values `0` and `1`; it can return `bool` [-Wboolean-return]"
             ]
@@ -28,7 +28,7 @@ spec = do
             , "  return 0;"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:1: function `a` only ever returns two values `-1` and `0`; it can return `bool` [-Wboolean-return]"
             ]
@@ -41,7 +41,7 @@ spec = do
             , "  return foo();"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             []
 
@@ -53,6 +53,6 @@ spec = do
             , "  return -1;"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             []

--- a/test/Tokstyle/Linter/BooleansSpec.hs
+++ b/test/Tokstyle/Linter/BooleansSpec.hs
@@ -3,7 +3,7 @@ module Tokstyle.Linter.BooleansSpec where
 
 import           Test.Hspec          (Spec, it, shouldBe)
 
-import           Tokstyle.Linter     (allWarnings, analyse)
+import           Tokstyle.Linter     (allWarnings, analyseLocal)
 import           Tokstyle.LinterSpec (mustParse)
 
 
@@ -16,7 +16,7 @@ spec = do
             , "  return false;"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:2: if-statement followed by boolean return can be simplified to return [-Wbooleans]"
             ]
@@ -28,7 +28,7 @@ spec = do
             , "  else { return false; }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:2: if/else with return true/false can be simplified to return [-Wbooleans]"
             ]
@@ -41,7 +41,7 @@ spec = do
             , "  return false;"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:3: if-statement followed by boolean return can be simplified to return [-Wbooleans]"
             ]

--- a/test/Tokstyle/Linter/CallocTypeSpec.hs
+++ b/test/Tokstyle/Linter/CallocTypeSpec.hs
@@ -3,7 +3,7 @@ module Tokstyle.Linter.CallocTypeSpec where
 
 import           Test.Hspec          (Spec, it, shouldBe)
 
-import           Tokstyle.Linter     (allWarnings, analyse)
+import           Tokstyle.Linter     (allWarnings, analyseLocal)
 import           Tokstyle.LinterSpec (mustParse)
 
 
@@ -15,7 +15,7 @@ spec = do
             , "  uint8_t *a = (uint8_t *)mem_alloc(mem, sizeof(uint8_t));"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             ["test.c:2: `mem_alloc` should not be used for `\ESC[32muint8_t\ESC[0m*`; use `mem_balloc` instead [-Wcalloc-type]"]
 
@@ -25,7 +25,7 @@ spec = do
             , "  uint8_t *a = (uint8_t *)mem_valloc(mem, 1);"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:2: invalid `mem_valloc` invocation: 2 arguments after `mem` expected [-Wcalloc-args]"
             , "test.c:2: the result of `mem_valloc` must be cast to its member type [-Wcalloc-type]"
@@ -37,7 +37,7 @@ spec = do
             , "  void *a = mem_valloc(mem, 2, sizeof(int));"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             ["test.c:2: the result of `mem_valloc` must be cast to its member type [-Wcalloc-type]"]
 
@@ -47,5 +47,5 @@ spec = do
             , "  Foo *a = (Foo *)mem_alloc(mem, sizeof(Foo));"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe` []

--- a/test/Tokstyle/Linter/CompoundInitSpec.hs
+++ b/test/Tokstyle/Linter/CompoundInitSpec.hs
@@ -3,7 +3,7 @@ module Tokstyle.Linter.CompoundInitSpec (spec) where
 
 import           Test.Hspec          (Spec, it, shouldBe)
 
-import           Tokstyle.Linter     (analyse)
+import           Tokstyle.Linter     (analyseLocal)
 import           Tokstyle.LinterSpec (mustParse)
 
 
@@ -15,7 +15,7 @@ spec = do
             , "  Foo foo = (Foo){0};"
             , "}"
             ]
-        analyse ["compound-init"] ("test.c", ast)
+        analyseLocal ["compound-init"] ("test.c", ast)
             `shouldBe`
             [ "test.c:2: don't use compound literals in initialisations; use simple `Type var = {0};` [-Wcompound-init]"
             ]
@@ -26,5 +26,5 @@ spec = do
             , "  Foo foo = {0};"
             , "}"
             ]
-        analyse ["compound-init"] ("test.c", ast)
+        analyseLocal ["compound-init"] ("test.c", ast)
             `shouldBe` []

--- a/test/Tokstyle/Linter/ConstnessSpec.hs
+++ b/test/Tokstyle/Linter/ConstnessSpec.hs
@@ -3,7 +3,7 @@ module Tokstyle.Linter.ConstnessSpec where
 
 import           Test.Hspec          (Spec, it, shouldBe)
 
-import           Tokstyle.Linter     (analyse)
+import           Tokstyle.Linter     (analyseLocal)
 import           Tokstyle.LinterSpec (mustParse)
 
 
@@ -17,7 +17,7 @@ spec = do
             , "  return *a + b[0];"
             , "}"
             ]
-        analyse ["constness"] ("test.c", ast)
+        analyseLocal ["constness"] ("test.c", ast)
             `shouldBe` []
 
     it "should give diagnostics on locals that can be const" $ do
@@ -27,7 +27,7 @@ spec = do
             , "  return a;"
             , "}"
             ]
-        analyse ["constness"] ("test.c", ast)
+        analyseLocal ["constness"] ("test.c", ast)
             `shouldBe`
             [ "test.c:2: variable `a` is never written to and can be declared `const` [-Wconstness]"
             ]

--- a/test/Tokstyle/Linter/ParensSpec.hs
+++ b/test/Tokstyle/Linter/ParensSpec.hs
@@ -3,7 +3,7 @@ module Tokstyle.Linter.ParensSpec where
 
 import           Test.Hspec          (Spec, it, shouldBe)
 
-import           Tokstyle.Linter     (allWarnings, analyse)
+import           Tokstyle.Linter     (allWarnings, analyseLocal)
 import           Tokstyle.LinterSpec (mustParse)
 
 
@@ -15,7 +15,7 @@ spec = do
             , "  return (1 + 2);"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:2: return expression does not need parentheses [-Wparens]"
             ]
@@ -26,4 +26,4 @@ spec = do
             , "  if ((true)) { return 3; }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe` []
+        analyseLocal allWarnings ("test.c", ast) `shouldBe` []

--- a/test/Tokstyle/Linter/SwitchIfSpec.hs
+++ b/test/Tokstyle/Linter/SwitchIfSpec.hs
@@ -3,7 +3,7 @@ module Tokstyle.Linter.SwitchIfSpec where
 
 import           Test.Hspec          (Spec, it, shouldBe)
 
-import           Tokstyle.Linter     (analyse)
+import           Tokstyle.Linter     (analyseLocal)
 import           Tokstyle.LinterSpec (mustParse)
 
 
@@ -20,7 +20,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["switch-if"] ("test.c", ast) `shouldBe` []
+        analyseLocal ["switch-if"] ("test.c", ast) `shouldBe` []
 
     it "accepts a if/else with only 2 comparisons" $ do
         ast <- mustParse
@@ -36,7 +36,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["switch-if"] ("test.c", ast) `shouldBe` []
+        analyseLocal ["switch-if"] ("test.c", ast) `shouldBe` []
 
     it "ignores candidates where all branches are single statements" $ do
         ast <- mustParse
@@ -50,7 +50,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["switch-if"] ("test.c", ast) `shouldBe` []
+        analyseLocal ["switch-if"] ("test.c", ast) `shouldBe` []
 
     it "diagnoses a series of if/else-if statements as candidate for switch" $ do
         ast <- mustParse
@@ -65,7 +65,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["switch-if"] ("test.c", ast)
+        analyseLocal ["switch-if"] ("test.c", ast)
             `shouldBe`
             [ "test.c:2: if-statement could be a switch [-Wswitch-if]"
             ]
@@ -85,7 +85,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["switch-if"] ("test.c", ast)
+        analyseLocal ["switch-if"] ("test.c", ast)
             `shouldBe`
             [ "test.c:2: if-statement could be a switch [-Wswitch-if]"
             ]
@@ -107,7 +107,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["switch-if"] ("test.c", ast)
+        analyseLocal ["switch-if"] ("test.c", ast)
             `shouldBe`
             [ "test.c:3: if-statement could be a switch [-Wswitch-if]"
             ]
@@ -131,7 +131,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["switch-if"] ("test.c", ast)
+        analyseLocal ["switch-if"] ("test.c", ast)
             `shouldBe`
             [ "test.c:5: if-statement could be a switch [-Wswitch-if]"
             ]
@@ -151,4 +151,4 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["switch-if"] ("test.c", ast) `shouldBe` []
+        analyseLocal ["switch-if"] ("test.c", ast) `shouldBe` []

--- a/test/Tokstyle/Linter/TypeCheckSpec.hs
+++ b/test/Tokstyle/Linter/TypeCheckSpec.hs
@@ -3,7 +3,7 @@ module Tokstyle.Linter.TypeCheckSpec where
 
 import           Test.Hspec          (Spec, it, shouldBe)
 
-import           Tokstyle.Linter     (analyse)
+import           Tokstyle.Linter     (analyseLocal)
 import           Tokstyle.LinterSpec (mustParse)
 
 
@@ -16,6 +16,6 @@ spec = do
             , "  put_int(i);"
             , "}"
             ]
-        analyse ["type-check"] ("test.c", ast)
+        analyseLocal ["type-check"] ("test.c", ast)
             `shouldBe`
             []

--- a/test/Tokstyle/Linter/VarUnusedInScopeSpec.hs
+++ b/test/Tokstyle/Linter/VarUnusedInScopeSpec.hs
@@ -3,7 +3,7 @@ module Tokstyle.Linter.VarUnusedInScopeSpec where
 
 import           Test.Hspec          (Spec, it, shouldBe)
 
-import           Tokstyle.Linter     (allWarnings, analyse)
+import           Tokstyle.Linter     (allWarnings, analyseLocal)
 import           Tokstyle.LinterSpec (mustParse)
 
 
@@ -18,7 +18,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["var-unused-in-scope"] ("test.c", ast)
+        analyseLocal ["var-unused-in-scope"] ("test.c", ast)
             `shouldBe`
             [ "test.c:2: variable `foo` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:4:   possibly to here [-Wvar-unused-in-scope]"
@@ -35,7 +35,7 @@ spec = do
             , "  print_int(*foo_ptr);"
             , "}"
             ]
-        analyse ["var-unused-in-scope"] ("test.c", ast) `shouldBe` []
+        analyseLocal ["var-unused-in-scope"] ("test.c", ast) `shouldBe` []
 
     it "ignores array-typed variables that escape the inner scope through assignment" $ do
         ast <- mustParse
@@ -48,7 +48,7 @@ spec = do
             , "  print(p);"
             , "}"
             ]
-        analyse ["var-unused-in-scope"] ("test.c", ast) `shouldBe` []
+        analyseLocal ["var-unused-in-scope"] ("test.c", ast) `shouldBe` []
 
     it "ignores array-typed variables assigned in a loop" $ do
         ast <- mustParse
@@ -63,7 +63,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["var-unused-in-scope"] ("test.c", ast) `shouldBe` []
+        analyseLocal ["var-unused-in-scope"] ("test.c", ast) `shouldBe` []
 
     it "keeps conditional variable initialisation out of the `if` statement if it's used after" $ do
         ast <- mustParse
@@ -78,7 +78,7 @@ spec = do
             , "  for (int i = 0; i < foo; ++i) { /* nothing */ }"
             , "}"
             ]
-        analyse ["var-unused-in-scope"] ("test.c", ast) `shouldBe` []
+        analyseLocal ["var-unused-in-scope"] ("test.c", ast) `shouldBe` []
 
     it "does not suggest moving complex initialisations into an if-statement" $ do
         ast <- mustParse
@@ -89,7 +89,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["var-unused-in-scope"] ("test.c", ast) `shouldBe` []
+        analyseLocal ["var-unused-in-scope"] ("test.c", ast) `shouldBe` []
 
     it "suggests moving trivial (pure) initialisations into an if-statement" $ do
         ast <- mustParse
@@ -100,7 +100,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["var-unused-in-scope"] ("test.c", ast)
+        analyseLocal ["var-unused-in-scope"] ("test.c", ast)
             `shouldBe`
             [ "test.c:2: variable `foo` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:4:   possibly to here [-Wvar-unused-in-scope]"
@@ -118,7 +118,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["var-unused-in-scope"] ("test.c", ast) `shouldBe` []
+        analyseLocal ["var-unused-in-scope"] ("test.c", ast) `shouldBe` []
 
     it "detects decls that can be for-init-decls" $ do
         ast <- mustParse
@@ -127,7 +127,7 @@ spec = do
             , "  for (i = 0; i < 10; ++i) { puts(\"hello!\"); }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:2: variable `i` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:3:   possibly to here [-Wvar-unused-in-scope]"
@@ -141,7 +141,7 @@ spec = do
             , "  for (int i = 0; i < 10; ++i) { /* nothing */ }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:2: variable `i` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:3:   possibly to here [-Wvar-unused-in-scope]"
@@ -153,7 +153,7 @@ spec = do
             , "  for (int i = 0; i < 10; ++i) { print_int(i); }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe` []
+        analyseLocal allWarnings ("test.c", ast) `shouldBe` []
 
     it "does not suggest reducing scope of loop bound constants" $ do
         ast <- mustParse
@@ -162,7 +162,7 @@ spec = do
             , "  for (int i = 0; i < bound; ++i) { print_int(i); }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe` []
+        analyseLocal allWarnings ("test.c", ast) `shouldBe` []
 
     it "considers `&var` a write to `var`" $ do
         ast <- mustParse
@@ -171,7 +171,7 @@ spec = do
             , "  for (int i = start(&foo); !stop(foo); i = incr(&foo)) { print_ints(i, foo); }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe` []
+        analyseLocal allWarnings ("test.c", ast) `shouldBe` []
 
     it "ignores function parameters" $ do
         ast <- mustParse
@@ -179,7 +179,7 @@ spec = do
             , "  for (i = 0; i < 10; ++i) { puts(\"hello!\"); }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe` []
+        analyseLocal allWarnings ("test.c", ast) `shouldBe` []
 
     it "supports #if/#endif" $ do
         ast <- mustParse
@@ -190,7 +190,7 @@ spec = do
             , "#endif"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:3: variable `i` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:4:   possibly to here [-Wvar-unused-in-scope]"
@@ -208,7 +208,7 @@ spec = do
             , "#endif"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:3: variable `i` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:4:   possibly to here [-Wvar-unused-in-scope]"
@@ -225,7 +225,7 @@ spec = do
             , "#endif"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:5: variable `i` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:6:   possibly to here [-Wvar-unused-in-scope]"
@@ -242,7 +242,7 @@ spec = do
             , "#endif"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:3: variable `i` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:4:   possibly to here [-Wvar-unused-in-scope]"
@@ -256,7 +256,7 @@ spec = do
             , "  for (i = 0; i < 10; ++i) { puts(\"hello!\"); }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:2: variable `i` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:3:   possibly to here [-Wvar-unused-in-scope]"
@@ -272,7 +272,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:2: variable `i` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:4:   possibly to here [-Wvar-unused-in-scope]"
@@ -289,7 +289,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:2: variable `i` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:6:   possibly to here [-Wvar-unused-in-scope]"
@@ -308,7 +308,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast)
+        analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
             [ "test.c:2: variable `i` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:8:   possibly to here [-Wvar-unused-in-scope]"
@@ -327,7 +327,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe` []
+        analyseLocal allWarnings ("test.c", ast) `shouldBe` []
 
     it "allows vars read in the same scope" $ do
         ast <- mustParse
@@ -337,7 +337,7 @@ spec = do
             , "  print_int(i);"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe` []
+        analyseLocal allWarnings ("test.c", ast) `shouldBe` []
 
     it "allows vars used as the bound for another for-loop" $ do
         ast <- mustParse
@@ -347,7 +347,7 @@ spec = do
             , "  for (int j = 0; j < i; ++j) { puts(\"hello!\"); }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe` []
+        analyseLocal allWarnings ("test.c", ast) `shouldBe` []
 
     it "treats array member assignment as read" $ do
         ast <- mustParse
@@ -356,7 +356,7 @@ spec = do
             , "  if (true) { c[0] = 'a'; }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe` []
+        analyseLocal allWarnings ("test.c", ast) `shouldBe` []
 
     it "treats dereference-and-assign as read" $ do
         ast <- mustParse
@@ -365,7 +365,7 @@ spec = do
             , "  if (true) { *c = 'a'; }"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe` []
+        analyseLocal allWarnings ("test.c", ast) `shouldBe` []
 
     it "should consider one `if` branch with a write as possibly not writing" $ do
         ast <- mustParse
@@ -380,7 +380,7 @@ spec = do
             , "  return 0;"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe` []
+        analyseLocal allWarnings ("test.c", ast) `shouldBe` []
 
     it "should combine 'either write or read' into 'just read'" $ do
         ast <- mustParse
@@ -397,7 +397,7 @@ spec = do
             , "  return 0;"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe` []
+        analyseLocal allWarnings ("test.c", ast) `shouldBe` []
 
     it "suggests reducing scope when all if-branches do writes" $ do
         ast <- mustParse
@@ -416,7 +416,7 @@ spec = do
             , "  return 0;"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe`
+        analyseLocal allWarnings ("test.c", ast) `shouldBe`
             -- This suggestion is not quite correct, but we have nothing to anchor the "possibly to
             -- here" part to, so we make a slightly wrong suggestion. Hence the "possibly". In
             -- reality, the declaration should be right before the first `if` on line 4.
@@ -438,7 +438,7 @@ spec = do
             , "  return 0;"
             , "}"
             ]
-        analyse allWarnings ("test.c", ast) `shouldBe`
+        analyseLocal allWarnings ("test.c", ast) `shouldBe`
             [ "test.c:2: variable `foo` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:4:   possibly to here [-Wvar-unused-in-scope]"
             ]
@@ -454,7 +454,7 @@ spec = do
             , "  }"
             , "}"
             ]
-        analyse ["var-unused-in-scope"] ("test.c", ast) `shouldBe`
+        analyseLocal ["var-unused-in-scope"] ("test.c", ast) `shouldBe`
             [ "test.c:5: variable `i` can be reduced in scope [-Wvar-unused-in-scope]"
             , "test.c:6:   possibly to here [-Wvar-unused-in-scope]"
             ]

--- a/test/Tokstyle/SemFmt/EnumFromIntSpec.hs
+++ b/test/Tokstyle/SemFmt/EnumFromIntSpec.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Tokstyle.SemFmt.EnumFromIntSpec where
+
+import           Test.Hspec             (Spec, it, shouldBe)
+
+import           Language.Cimple.Pretty (ppTranslationUnit, render)
+
+import           Tokstyle.Linter        (analyseGlobal)
+import           Tokstyle.LinterSpec    (mustParse, mustParseStmt)
+
+
+spec :: Spec
+spec = do
+    it "should give diagnostics on incorrect from_int function" $ do
+        ast <- mustParse
+            [ "typedef enum Foo {"
+            , "  FOO_ONE,"
+            , "  FOO_TWO,"
+            , "} Foo;"
+            , "Foo foo_from_int(int b) {"
+            , "  switch (b) {"
+            , "    case FOO_ONE: return FOO_ONE;"
+            , "    case FOO_TWO: return FOO_ONE;"
+            , "    default: return FOO_ONE;"
+            , "  }"
+            , "}"
+            ]
+        expected <- render . ppTranslationUnit . (:[]) <$> mustParseStmt
+            [ "{"
+            , "  switch (b) {"
+            , "    case FOO_ONE: return FOO_ONE;"
+            , "    case FOO_TWO: return FOO_TWO;"
+            , "    default: return FOO_ONE;"
+            , "  }"
+            , "}"
+            ]
+        analyseGlobal ["enum-from-int"] [("test.c", ast)]
+            `shouldBe`
+            [ "test.c:5: enum from_int function should be:\n" <> expected <> " [-Wenum-from-int]"
+            ]

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -50,6 +50,7 @@ library
     Tokstyle.Linter.TypedefName
     Tokstyle.Linter.UnsafeFunc
     Tokstyle.Linter.VarUnusedInScope
+    Tokstyle.SemFmt.EnumFromInt
 
   ghc-options:      -Wall
   hs-source-dirs:   src
@@ -59,11 +60,12 @@ library
     , array           <0.6
     , base            >=4       && <5
     , bytestring      <0.13
-    , cimple          >=0.0.17
+    , cimple          >=0.0.18
     , containers      <0.8
     , data-fix        <0.4
     , deepseq         <2
     , edit-distance   <0.3
+    , extra           <2
     , filepath        <2
     , groom           <0.2
     , microlens       <0.5
@@ -132,6 +134,7 @@ test-suite testsuite
     Tokstyle.Linter.TypeCheckSpec
     Tokstyle.Linter.VarUnusedInScopeSpec
     Tokstyle.LinterSpec
+    Tokstyle.SemFmt.EnumFromIntSpec
 
   ghc-options:        -Wall -Wno-unused-imports
   build-tool-depends: hspec-discover:hspec-discover

--- a/tools/check-c.hs
+++ b/tools/check-c.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ViewPatterns    #-}
 {-# OPTIONS_GHC -Wno-missing-pattern-synonym-signatures #-}
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
+{- HLINT ignore "Use camelCase" -}
 module Main (main) where
 
 import           Control.Monad                   (forM_, unless, zipWithM_)
@@ -119,8 +120,8 @@ checkAssign c l r             = checkConversion c l r
 
 sameEnum :: MonadTrav m => Type -> Type -> (Ident, Expr) -> (Ident, Expr) -> m ()
 sameEnum leftTy rightTy (leftId, leftExpr) (rightId, rightExpr) = do
-    leftVal  <- getJust failMsg =<< intValue <$> constEval defaultMD Map.empty leftExpr
-    rightVal <- getJust failMsg =<< intValue <$> constEval defaultMD Map.empty rightExpr
+    leftVal  <- getJust failMsg . intValue =<< constEval defaultMD Map.empty leftExpr
+    rightVal <- getJust failMsg . intValue =<< constEval defaultMD Map.empty rightExpr
     unless (leftVal == rightVal) $
         throwTravError $ typeMismatch
             ("invalid cast: enumerator value for `"

--- a/tools/check-cimple.hs
+++ b/tools/check-cimple.hs
@@ -16,13 +16,13 @@ import qualified Language.Cimple.Program     as Program
 import           System.Environment          (getArgs)
 import           System.IO                   (hPutStrLn, stderr)
 
-import           Tokstyle.Linter             (allWarnings, analyse,
-                                              analyseGlobal)
+import           Tokstyle.Linter             (allWarnings, analyseGlobal,
+                                              analyseLocal)
 
 
 processAst :: [Text] -> (UTCTime, [(FilePath, [Node (Lexeme Text)])]) -> IO ()
 processAst ignore (start, tus) = do
-    report $ concat $ analyseGlobal ignore tus : parMap rpar (analyse ignore) tus
+    report $ concat $ analyseGlobal ignore tus : parMap rpar (analyseLocal ignore) tus
     end <- getCurrentTime
     hPutStrLn stderr $ "Linting: " <> show (diffUTCTime end start)
   where

--- a/web/Tokstyle/App.hs
+++ b/web/Tokstyle/App.hs
@@ -15,7 +15,7 @@ import           Servant
 
 import           Language.Cimple          (Lexeme, Node)
 import qualified Language.Cimple.IO       as Cimple
-import           Tokstyle.Linter          (allWarnings, analyse)
+import           Tokstyle.Linter          (allWarnings, analyseLocal)
 
 
 type ParseResult = Either String [Node (Lexeme Text)]
@@ -53,7 +53,7 @@ server =
     parseH = return . Cimple.parseText . Text.decodeUtf8With Text.lenientDecode
 
     analyseH (file, Left  err) = return [Text.pack $ file <> ":" <> err]
-    analyseH (file, Right ast) = return $ analyse webWarnings (file, ast)
+    analyseH (file, Right ast) = return $ analyseLocal webWarnings (file, ast)
 
 -- Turn the server into a WAI app. 'serve' is provided by servant,
 -- more precisely by the Servant.Server module.

--- a/web/webservice.hs
+++ b/web/webservice.hs
@@ -23,4 +23,4 @@ main = do
     args <- getArgs
     case args of
         [port] -> runTestServer $ read port
-        _      -> runTestServer =<< read <$> getEnv "PORT"
+        _      -> runTestServer . read =<< getEnv "PORT"


### PR DESCRIPTION
This is the first "semantic formatter" style linter. It's pretty simple and just checks that all enumerators are present and there is a sane default in the `${enum}_from_int` functions. There is no compiler warning we can use for this, because the int can contain anything. Currently, if there is an enumerator ending in `_INVALID`, then that is the default, otherwise the first enumerator is the default for invalid int values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/212)
<!-- Reviewable:end -->
