### PR TITLE
feat: Add `-Wnesting` to limit nesting depth in functions.

### DIFF
--- a/src/Tokstyle/Linter.hs
+++ b/src/Tokstyle/Linter.hs
@@ -30,6 +30,7 @@ import qualified Tokstyle.Linter.LoggerNoEscapes   as LoggerNoEscapes
 import qualified Tokstyle.Linter.MallocType        as MallocType
 import qualified Tokstyle.Linter.MemcpyStructs     as MemcpyStructs
 import qualified Tokstyle.Linter.MissingNonNull    as MissingNonNull
+import qualified Tokstyle.Linter.Nesting           as Nesting
 import qualified Tokstyle.Linter.NonNull           as NonNull
 import qualified Tokstyle.Linter.Parens            as Parens
 import qualified Tokstyle.Linter.SwitchIf          as SwitchIf
@@ -77,6 +78,7 @@ localLinters =
     , ("malloc-type"        , MallocType.analyse       )
     , ("memcpy-structs"     , MemcpyStructs.analyse    )
     , ("missing-non-null"   , MissingNonNull.analyse   )
+    , ("nesting"            , Nesting.analyse          )
     , ("non-null"           , NonNull.analyse          )
     , ("parens"             , Parens.analyse           )
     , ("switch-if"          , SwitchIf.analyse         )

--- a/src/Tokstyle/Linter/Nesting.hs
+++ b/src/Tokstyle/Linter/Nesting.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE LambdaCase        #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict            #-}
+module Tokstyle.Linter.Nesting where
+
+import           Control.Monad               (when)
+import           Control.Monad.State.Strict  (State)
+import qualified Control.Monad.State.Strict  as State
+import           Data.Fix                    (Fix (..), foldFix)
+import           Data.Text                   (Text)
+import qualified Data.Text                   as Text
+import           Language.Cimple             (Lexeme (..), Node, NodeF (..))
+import           Language.Cimple.Diagnostics (warn)
+import           Language.Cimple.TraverseAst (AstActions, astActions, doNode,
+                                              traverseAst)
+
+maxNesting :: Int
+maxNesting = 7  -- TODO(iphydf): Reduce.
+
+countNesting :: NodeF (Lexeme Text) Int -> Int
+countNesting = \case
+    CompoundStmt ns -> 1 + foldr max 0 ns
+    ns              -> foldr max 0 ns
+
+
+linter :: AstActions (State [Text]) Text
+linter = astActions
+    { doNode = \file node act ->
+        case unFix node of
+            FunctionDefn{} ->
+                let nesting = foldFix countNesting node in
+                when (nesting > maxNesting) $
+                    warn file node $ "function is too deeply nested: "
+                        <> Text.pack (show nesting) <> " is deeper than the "
+                        <> "maximum allowed of " <> Text.pack (show maxNesting)
+                        <> "; consider inversion or extraction"
+
+            _ -> act
+    }
+
+analyse :: (FilePath, [Node (Lexeme Text)]) -> [Text]
+analyse = reverse . flip State.execState [] . traverseAst linter

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -55,6 +55,7 @@ library
     Tokstyle.Linter.MallocType
     Tokstyle.Linter.MemcpyStructs
     Tokstyle.Linter.MissingNonNull
+    Tokstyle.Linter.Nesting
     Tokstyle.Linter.NonNull
     Tokstyle.Linter.Parens
     Tokstyle.Linter.SwitchIf


### PR DESCRIPTION
Right now, `send_crypto_packets` is deeply nested and terrible. Once that's fixed, we can reduce this number by a bit. Generally we should avoid deep nesting and instead extract functions or invert conditions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/224)
<!-- Reviewable:end -->
