### PR TITLE
feat: `-Wvoid-call` to validate the format of callback handlers.

### DIFF
--- a/src/Tokstyle/C/Env.hs
+++ b/src/Tokstyle/C/Env.hs
@@ -5,15 +5,25 @@ module Tokstyle.C.Env where
 import           Language.C.Analysis.SemRep    (Type)
 import           Language.C.Analysis.TravMonad (Trav, getUserState,
                                                 modifyUserState)
+import           Language.C.Data.Ident         (Ident)
 import           Tokstyle.C.TravUtils          (getJust)
 
 data Env = Env
-    { ctx   :: [String]
-    , retTy :: Maybe Type
+    { ctx    :: [String]
+    , retTy  :: Maybe Type
+    , params :: [Ident]
     }
 
 defaultEnv :: Env
-defaultEnv = Env ["file"] Nothing
+defaultEnv = Env ["file"] Nothing []
+
+bracketUserState :: (s -> s) -> Trav s a -> Trav s a
+bracketUserState f act = do
+    s <- getUserState
+    modifyUserState f
+    r <- act
+    modifyUserState (const s)
+    return r
 
 
 getCtx :: Trav Env [String]

--- a/src/Tokstyle/C/Linter.hs
+++ b/src/Tokstyle/C/Linter.hs
@@ -19,6 +19,7 @@ import qualified Tokstyle.C.Linter.Cast           as Cast
 import qualified Tokstyle.C.Linter.Conversion     as Conversion
 import qualified Tokstyle.C.Linter.Memset         as Memset
 import qualified Tokstyle.C.Linter.Sizeof         as Sizeof
+import qualified Tokstyle.C.Linter.VoidCall       as VoidCall
 
 
 linters :: [(Text, GlobalDecls -> Trav Env ())]
@@ -28,6 +29,7 @@ linters =
     , ("conversion"         , Conversion.analyse       )
     , ("memset"             , Memset.analyse           )
     , ("sizeof"             , Sizeof.analyse           )
+    , ("void-call"          , VoidCall.analyse         )
     ]
 
 runLinters :: [Text] -> GlobalDecls -> Trav Env ()

--- a/src/Tokstyle/C/Linter/Memset.hs
+++ b/src/Tokstyle/C/Linter/Memset.hs
@@ -35,7 +35,7 @@ hasPtrs ty = case canonicalType ty of
             _ ->
                 throwTravError $ userErr $
                     "couldn't find struct/union type `" <> show (pretty name) <> "`"
-    PtrType _ _ _ -> return True
+    PtrType{} -> return True
     _ -> return False
 
 memberHasPtrs :: MonadTrav m => MemberDecl -> m Bool

--- a/src/Tokstyle/C/Linter/VoidCall.hs
+++ b/src/Tokstyle/C/Linter/VoidCall.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms   #-}
+{-# LANGUAGE Strict            #-}
+{-# OPTIONS_GHC -Wwarn #-}
+module Tokstyle.C.Linter.VoidCall (analyse) where
+
+import           Data.Functor.Identity           (Identity)
+import           Data.List                       (isPrefixOf)
+import           Data.Maybe                      (mapMaybe)
+import           Language.C                      (Annotated (annotation),
+                                                  CCompoundBlockItem (CBlockDecl),
+                                                  CDeclaration (CDecl),
+                                                  CDeclarator (CDeclr),
+                                                  CDerivedDeclarator (CPtrDeclr),
+                                                  CExpression (CCast, CVar),
+                                                  CInitializer (CInitExpr),
+                                                  CStatement (CCompound), Ident,
+                                                  NodeInfo, Pretty (pretty))
+import           Language.C.Analysis.AstAnalysis (ExprSide (RValue), tExpr)
+import           Language.C.Analysis.SemError    (invalidAST)
+import           Language.C.Analysis.SemRep      (FunDef (..), FunType (..),
+                                                  GlobalDecls, IdentDecl (..),
+                                                  ParamDecl (..), Type (..),
+                                                  VarDecl (..), VarName (..))
+import           Language.C.Analysis.TravMonad   (MonadCError (recordError),
+                                                  Trav, TravT)
+import           Language.C.Data.Ident           (Ident (Ident))
+import           Tokstyle.C.Env                  (Env (params),
+                                                  bracketUserState)
+import           Tokstyle.C.Patterns
+import           Tokstyle.C.TraverseAst          (AstActions (..), astActions,
+                                                  traverseAst)
+
+voidPtrParams :: [ParamDecl] -> [Ident]
+voidPtrParams = mapMaybe isVoidPtr
+  where
+    isVoidPtr (ParamDecl (VarDecl (VarName x _) _ TY_void_ptr) _) = Just x
+    isVoidPtr _                                                   = Nothing
+
+
+pattern VPtrCast :: CExpression a -> Ident -> CExpression a
+pattern VPtrCast var ref <- (CCast (CDecl _ [(Just (CDeclr _ [CPtrDeclr [] _] _ [] _),_,_)] _) var@(CVar ref _) _)
+
+pattern VParamCast :: Ident -> CCompoundBlockItem a
+pattern VParamCast ref <- CBlockDecl (CDecl _ [(Just (CDeclr _ [CPtrDeclr _ _] _ [] _),Just (CInitExpr (VPtrCast _ ref) _),_)] _)
+
+linter :: AstActions (TravT Env Identity)
+linter = astActions
+    { doIdentDecl = \node act -> case node of
+        FunctionDef (FunDef (VarDecl (VarName fname _) _ (FunctionType (FunType _ ps _) _)) (CCompound _ body _) _)
+            | "sys_" `isPrefixOf` idName fname -> return ()
+            | otherwise -> checkFunction (voidPtrParams ps) body
+
+        _ -> act
+
+    , doExpr = \node act -> case node of
+        VPtrCast e n -> do
+            dstTy <- tExpr [] RValue node
+            srcTy <- tExpr [] RValue e
+            case srcTy of
+                TY_void_ptr ->
+                    recordError $ invalidAST (annotation node) $
+                        "first statement must cast `void *" <> idName n <> "` to `" <> show (pretty dstTy) <> "`"
+                _ -> return ()
+
+        _ -> act
+    }
+  where
+    idName (Ident name _ _) = name
+
+    checkFunction :: [Ident] -> [CCompoundBlockItem NodeInfo] -> TravT Env Identity ()
+    checkFunction [] _                    = return ()  -- ignore functions without vptr param
+    checkFunction _ []                    = return ()  -- ignore empty functions
+    checkFunction vptrs (VParamCast _:ss) = checkFunction vptrs ss
+    checkFunction vptrs body              = checkCastInit vptrs (traverseAst linter body)
+
+    checkCastInit :: [Ident] -> TravT Env Identity () -> TravT Env Identity ()
+    checkCastInit vptrs = bracketUserState (\env -> env{params = vptrs})
+
+
+analyse :: GlobalDecls -> Trav Env ()
+analyse = traverseAst linter

--- a/test/Tokstyle/C/Linter/VoidCallSpec.hs
+++ b/test/Tokstyle/C/Linter/VoidCallSpec.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Tokstyle.C.Linter.VoidCallSpec (spec) where
+
+import           Test.Hspec            (Spec, it, shouldBe)
+
+import qualified Data.Text             as Text
+import           Tokstyle.C.Linter     (allWarnings, analyse)
+import           Tokstyle.C.LinterSpec (mustParse)
+
+
+spec :: Spec
+spec = do
+    it "warns if there is code before the cast-from-void" $ do
+        ast <- mustParse
+            [ "void add_handler(int *a, void *user_data) {"
+            , "  if (user_data == 0) { return; }"  -- this should be done *after* the cast
+            , "  const int *b = (const int *)user_data;"
+            , "  *a += *b;"
+            , "}"
+            ]
+        analyse allWarnings ast
+            `shouldBe`
+            [ Text.unlines
+                [ "test.c:3: (column 18) [ERROR]  >>> AST invariant violated"
+                , "  first statement must cast `void *user_data` to `const int *`"
+                ]
+            ]
+
+    it "warns if there is code before the cast-from-void in multi-vptr function" $ do
+        ast <- mustParse
+            [ "void add_handler(void *obj, void *user_data) {"
+            , "  if (user_data == 0) { return; }"  -- this should be done *after* the cast
+            , "  int *b = (int *)obj;"
+            , "  *b += 3;"
+            , "}"
+            ]
+        analyse allWarnings ast
+            `shouldBe`
+            [ Text.unlines
+                [ "test.c:3: (column 12) [ERROR]  >>> AST invariant violated"
+                , "  first statement must cast `void *obj` to `int *`"
+                ]
+            ]
+
+    it "doesn't warn if there is no cast-from-void" $ do
+        ast <- mustParse
+            [ "void add_handler(int *a, void *user_data) {"
+            , "  *a += 3;"
+            , "}"
+            ]
+        analyse allWarnings ast
+            `shouldBe` []
+
+    it "accepts the correct handler function format" $ do
+        ast <- mustParse
+            [ "void add_handler(int *a, void *user_data) {"
+            , "  int *b = (int *)user_data;"
+            , "  *a += *b;"
+            , "}"
+            ]
+        analyse allWarnings ast
+            `shouldBe` []
+
+    it "accepts multiple differently-typed void pointer arguments" $ do
+        ast <- mustParse
+            [ "void add_handler(void *va, void *vb) {"
+            , "  long *a = (long *)va;"
+            , "  int *b = (int *)vb;"
+            , "  *a += *b;"
+            , "}"
+            ]
+        analyse allWarnings ast
+            `shouldBe` []
+
+    it "allows the declaration to be const-qualified" $ do
+        ast <- mustParse
+            [ "void add_handler(int *a, void *user_data) {"
+            , "  int *const b = (int *)user_data;"
+            , "  *a += *b;"
+            , "}"
+            ]
+        analyse allWarnings ast
+            `shouldBe` []
+
+    it "warns on cast-from-vptr outside the first declaration statement" $ do
+        ast <- mustParse
+            [ "void do_something(int *a, int *b);"
+            , "void add_handler(int *a, void *user_data) {"
+            , "  do_something(a, (int *)user_data);"
+            , "}"
+            ]
+        analyse allWarnings ast
+            `shouldBe`
+            [ Text.unlines
+                [ "test.c:3: (column 19) [ERROR]  >>> AST invariant violated"
+                , "  first statement must cast `void *user_data` to `int *`"
+                ]
+            ]
+
+    it "accepts passing void pointers as-is" $ do
+        ast <- mustParse
+            [ "void do_something(void *user_data);"
+            , "void add_handler(int *a, void *user_data) {"
+            , "  do_something(user_data);"
+            , "}"
+            ]
+        analyse allWarnings ast
+            `shouldBe` []

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -25,6 +25,7 @@ library
     Tokstyle.C.Linter.Conversion
     Tokstyle.C.Linter.Memset
     Tokstyle.C.Linter.Sizeof
+    Tokstyle.C.Linter.VoidCall
     Tokstyle.C.Patterns
     Tokstyle.C.TravUtils
     Tokstyle.C.TraverseAst
@@ -143,6 +144,7 @@ test-suite testsuite
   other-modules:
     Tokstyle.C.Linter.MemsetSpec
     Tokstyle.C.Linter.SizeofSpec
+    Tokstyle.C.Linter.VoidCallSpec
     Tokstyle.C.LinterSpec
     Tokstyle.Linter.BooleanReturnSpec
     Tokstyle.Linter.BooleansSpec


### PR DESCRIPTION
They must always start with the cast from `void*` to whatever `T*` they are actually handling. This makes it easier to read and understand that the `void*` is actually a `T*`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/231)
<!-- Reviewable:end -->
