### PR TITLE
fix: Allow non-const array to be assigned to const array.

### DIFF
--- a/src/Tokstyle/C/Linter/Conversion.hs
+++ b/src/Tokstyle/C/Linter/Conversion.hs
@@ -52,6 +52,7 @@ checkConversion _ (_, rTy) (_, lTy) | isEnumConversion (canonicalType lTy) rTy =
 checkConversion context (r, removeQuals -> rTy) (l, removeQuals -> lTy) =
     case (show $ pretty rTy, show $ pretty lTy) of
       (rTyName, lTyName) | rTyName == lTyName -> return ()
+      ("uint8_t [32]","uint8_t const [32]") -> return ()
       ("char *","const char *")         -> return ()
       ("const int *","const char *")    -> return ()
       ("int","vpx_codec_er_flags_t")    -> return ()


### PR DESCRIPTION
We should really do a const removal from array/pointer types for this check, but for now this works.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/234)
<!-- Reviewable:end -->
