### PR TITLE
fix: Exempt cmp.c from conversion checking.

### DIFF
--- a/tools/check-c.hs
+++ b/tools/check-c.hs
@@ -19,8 +19,10 @@ import           Tokstyle.C.Linter      (allWarnings, analyse)
 
 defaultCppOpts :: String -> [String]
 defaultCppOpts sysInclude =
-    [ "-nostdinc"  -- we have our own stdlib headers
-    , "-undef"     -- no __linux__
+    [ "-DCMP_NO_FLOAT"      -- avoid float->char* casts
+    , "-DWORDS_BIGENDIAN=0" -- avoid casting in is_bigendian()
+    , "-nostdinc"           -- we have our own stdlib headers
+    , "-undef"              -- no __linux__
     , "-I" <> sysInclude
     , "-I" <> sysInclude <> "/opus"
     ]


### PR DESCRIPTION
Also disable float code from cmp.c, which is non-portable and we don't use it anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/243)
<!-- Reviewable:end -->
