### PR TITLE
fix: Add missing `crypto_box_MACBYTES`.

### DIFF
--- a/src/Tokstyle/Linter/Callgraph.hs
+++ b/src/Tokstyle/Linter/Callgraph.hs
@@ -351,6 +351,7 @@ analyse = reverse . flip State.execState [] . linter . (builtins <>) . callgraph
         , "crypto_box_BEFORENMBYTES"
         , "crypto_box_BOXZEROBYTES"
         , "crypto_box_keypair"
+        , "crypto_box_MACBYTES"
         , "crypto_box_NONCEBYTES"
         , "crypto_box_open_afternm"
         , "crypto_box_PUBLICKEYBYTES"


### PR DESCRIPTION
Toxcore defines this manually at the moment, but libsodium already does.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/250)
<!-- Reviewable:end -->
