### PR TITLE
fix: Adapt to prettyprinter changes in cimple.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@
 packages: [.]
 resolver: lts-21.9
 extra-deps:
-  - cimple-0.0.21
+  - cimple-0.0.22

--- a/test/Tokstyle/Linter/CallocTypeSpec.hs
+++ b/test/Tokstyle/Linter/CallocTypeSpec.hs
@@ -17,7 +17,7 @@ spec = do
             ]
         analyseLocal allWarnings ("test.c", ast)
             `shouldBe`
-            ["test.c:2: `mem_alloc` should not be used for `\ESC[32muint8_t\ESC[0m*`; use `mem_balloc` instead [-Wcalloc-type]"]
+            ["test.c:2: `mem_alloc` should not be used for `\ESC[0;32muint8_t\ESC[0m*`; use `mem_balloc` instead [-Wcalloc-type]"]
 
     it "detects when mem_valloc() result is cast to the wrong type" $ do
         ast <- mustParse

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -81,7 +81,7 @@ library
     , array           <0.6
     , base            >=4       && <5
     , bytestring      <0.13
-    , cimple          >=0.0.21
+    , cimple          >=0.0.22
     , casing          <0.2
     , containers      <0.8
     , data-fix        <0.4
@@ -148,6 +148,7 @@ test-suite testsuite
   hs-source-dirs:     test
   main-is:            testsuite.hs
   other-modules:
+    Tokstyle.C.Linter.CallbackParamsSpec
     Tokstyle.C.Linter.MemsetSpec
     Tokstyle.C.Linter.SizeArgSpec
     Tokstyle.C.Linter.SizeofSpec


### PR DESCRIPTION
Colours are now rendered with `\ESC[0;NNm`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/258)
<!-- Reviewable:end -->
