### PR TITLE
fix: Support `_e` suffix for internal cmp enums.

### DIFF
--- a/src/Tokstyle/Linter/Callgraph.hs
+++ b/src/Tokstyle/Linter/Callgraph.hs
@@ -142,7 +142,7 @@ callgraph = funcs . mconcat . concatMap (uncurry $ map . foldFix . go)
 
     go file (Union  name envs) = empty{funcs = Map.singleton (Name NKType file name) (outgoing $ fold envs)}
     go file (Struct name envs) = empty{funcs = Map.singleton (Name NKType file name) (outgoing $ fold envs)}
-    go file (EnumDecl name envs _) =
+    go file (EnumDecl _ envs name) =
         let Env{outgoing, funcs} = fold envs in
         empty{funcs = Map.insert (Name NKType file name) outgoing funcs}
     go file (Typedef env name) =

--- a/src/Tokstyle/Linter/EnumNames.hs
+++ b/src/Tokstyle/Linter/EnumNames.hs
@@ -102,6 +102,7 @@ linter = astActions
         [name]
         ++ allowSuffix "_TYPE_"
         ++ allowSuffix "_T_"
+        ++ allowSuffix "_E_"  -- for cmp
       where
         allowSuffix s = maybeToList ((<>"_") <$> Text.stripSuffix s name)
 

--- a/src/Tokstyle/Linter/TypedefName.hs
+++ b/src/Tokstyle/Linter/TypedefName.hs
@@ -19,7 +19,7 @@ valid :: Lexeme Text -> Lexeme Text -> Bool
 valid (L _ _ tname) (L _ _ sname) =
     sname == tname || fromMaybe False (do
         t <- Text.stripSuffix "_t" tname
-        s <- Text.stripSuffix "_s" sname <|> Text.stripSuffix "_u" sname
+        s <- Text.stripSuffix "_s" sname <|> Text.stripSuffix "_u" sname <|> Text.stripSuffix "_e" sname
         return $ t == s)
 
 linter :: AstActions (State [Text]) Text


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/260)
<!-- Reviewable:end -->
