### PR TITLE
cleanup: Use `tools` instead of `exec_tools`.

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -2,8 +2,8 @@ genrule(
     name = "cimple_doc",
     outs = ["cimple.md.new"],
     cmd = "$(location //hs-tokstyle/tools:check-cimple) --help > $@",
-    exec_tools = ["//hs-tokstyle/tools:check-cimple"],
     tags = ["no-cross"],
+    tools = ["//hs-tokstyle/tools:check-cimple"],
 )
 
 sh_test(


### PR DESCRIPTION
The latter is deprecated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/262)
<!-- Reviewable:end -->
