### PR TITLE
feat: Add support for variable array indices in access paths.

### DIFF
--- a/src/Tokstyle/Analysis/AccessPath.hs
+++ b/src/Tokstyle/Analysis/AccessPath.hs
@@ -3,6 +3,7 @@
 module Tokstyle.Analysis.AccessPath
     ( AccessPath (..)
     , isPathPrefixOf
+    , pathDepth
     ) where
 
 import           Prettyprinter (Pretty (..))
@@ -32,3 +33,11 @@ isPathPrefixOf p1 (PathDeref p2)   = p1 `isPathPrefixOf` p2
 isPathPrefixOf p1 (PathField p2 _) = p1 `isPathPrefixOf` p2
 isPathPrefixOf PathReturn _        = False
 isPathPrefixOf _ _                 = False
+
+pathDepth :: AccessPath -> Int
+pathDepth = \case
+    PathVar _     -> 1
+    PathParam _   -> 1
+    PathReturn    -> 1
+    PathDeref p   -> 1 + pathDepth p
+    PathField p _ -> 1 + pathDepth p

--- a/src/Tokstyle/Analysis/AccessPath.hs
+++ b/src/Tokstyle/Analysis/AccessPath.hs
@@ -15,6 +15,7 @@ data AccessPath
     | PathReturn
     | PathDeref AccessPath
     | PathField AccessPath String
+    | PathIndex AccessPath String
     deriving (Show, Eq, Ord)
 
 instance Pretty AccessPath where
@@ -24,6 +25,7 @@ instance Pretty AccessPath where
         PathReturn    -> "<return value>"
         PathDeref p   -> "*" <> pretty p
         PathField p s -> pretty p <> "->" <> pretty s
+        PathIndex p i -> pretty p <> "[" <> pretty i <> "]"
 
 -- | Check if the first path is a prefix of (or equal to) the second.
 -- e.g. "p" is a prefix of "p->f".
@@ -31,6 +33,7 @@ isPathPrefixOf :: AccessPath -> AccessPath -> Bool
 isPathPrefixOf p1 p2               | p1 == p2 = True
 isPathPrefixOf p1 (PathDeref p2)   = p1 `isPathPrefixOf` p2
 isPathPrefixOf p1 (PathField p2 _) = p1 `isPathPrefixOf` p2
+isPathPrefixOf p1 (PathIndex p2 _) = p1 `isPathPrefixOf` p2
 isPathPrefixOf PathReturn _        = False
 isPathPrefixOf _ _                 = False
 
@@ -41,3 +44,4 @@ pathDepth = \case
     PathReturn    -> 1
     PathDeref p   -> 1 + pathDepth p
     PathField p _ -> 1 + pathDepth p
+    PathIndex p _ -> 1 + pathDepth p

--- a/src/Tokstyle/C/Linter/BorrowCheck.hs
+++ b/src/Tokstyle/C/Linter/BorrowCheck.hs
@@ -251,6 +251,7 @@ summariseFunction = \case
     mapToParam _ PathReturn = PathReturn
     mapToParam params (PathDeref p) = PathDeref (mapToParam params p)
     mapToParam params (PathField p f) = PathField (mapToParam params p) f
+    mapToParam params (PathIndex p i) = PathIndex (mapToParam params p) i
 
     isParam v (ParamDecl (VarDecl (VarName (idName -> name) _) _ _) _) = name == v
     isParam _ _                                                       = False

--- a/test/Tokstyle/Analysis/SymbolicSpec.hs
+++ b/test/Tokstyle/Analysis/SymbolicSpec.hs
@@ -20,6 +20,7 @@ instance Arbitrary AccessPath where
             [ PathVar <$> elements ["p", "q", "r", "s", "t"]
             , PathDeref <$> arbPath (n `div` 2)
             , PathField <$> arbPath (n `div` 2) <*> elements ["x", "y", "z"]
+            , PathIndex <$> arbPath (n `div` 2) <*> elements ["i", "j", "0", "1"]
             ]
 
     shrink (PathVar _)     = []
@@ -27,6 +28,7 @@ instance Arbitrary AccessPath where
     shrink PathReturn      = []
     shrink (PathDeref p)   = p : [PathDeref p' | p' <- shrink p]
     shrink (PathField p f) = p : [PathField p' f | p' <- shrink p]
+    shrink (PathIndex p i) = p : [PathIndex p' i | p' <- shrink p]
 
 instance Arbitrary SVal where
     arbitrary = sized arbSVal

--- a/test/Tokstyle/Linter/NullabilitySpec.hs
+++ b/test/Tokstyle/Linter/NullabilitySpec.hs
@@ -314,6 +314,25 @@ spec = do
                        ]
             shouldAccept' code
 
+        it "tracks nullability for array access with variable index" $ do
+            let code = [ "void my_func(int **arr, int i) {"
+                       , "  if (arr[i] != nullptr) {"
+                       , "    *arr[i] = 1;"
+                       , "  }"
+                       , "}"
+                       ]
+            shouldAccept' code
+
+        it "tracks assignments to array access with variable index" $ do
+            let code = [ "void my_func(int *_Nullable *_Nonnull arr, int i) {"
+                       , "  int *p = (int *)malloc(sizeof(int));"
+                       , "  if (p == nullptr) return;"
+                       , "  arr[i] = p;"
+                       , "  *arr[i] = 1;"
+                       , "}"
+                       ]
+            shouldAccept' code
+
     describe "dereferences" $ do
         it "warns when a nullable pointer is dereferenced without check" $ do
             let code = [ "void my_func(int *_Nullable p) {"


### PR DESCRIPTION
This allows the nullability linter to track pointer states in array
accesses like `arr[i]` by using a stringified representation of the
index expression. Not super precise, but avoids common false positives.
We're not aiming for program proofs here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/284)
<!-- Reviewable:end -->
