### PR TITLE
feat: Improve nullability and ownership-decls diagnostics.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@
 packages: [.]
 resolver: lts-21.9
 extra-deps:
-  - cimple-0.0.31
+  - cimple-0.0.32

--- a/tokstyle.cabal
+++ b/tokstyle.cabal
@@ -95,7 +95,7 @@ library
     , array           <0.6
     , base            >=4       && <5
     , bytestring      <0.13
-    , cimple          >=0.0.31
+    , cimple          >=0.0.32
     , casing          <0.2
     , containers      <0.8
     , data-fix        <0.4

--- a/tools/check-cimple.hs
+++ b/tools/check-cimple.hs
@@ -15,6 +15,7 @@ import           Data.Time.Clock               (UTCTime, diffUTCTime,
                                                 getCurrentTime)
 import           Language.Cimple               (Lexeme, Node)
 import           Language.Cimple.Diagnostics   (CimplePos, Diagnostic (..),
+                                                DiagnosticSpan (..),
                                                 IsPosition (..), renderPure)
 import           Language.Cimple.IO            (parseProgram)
 import qualified Language.Cimple.Program       as Program
@@ -35,7 +36,9 @@ processAst ignore (start, tus) = do
   where
     report [] = return ()
     report diags = do
-        let files = Map.keys . Map.fromList $ [ (posFile (diagPos e), ()) | e <- diags ]
+        let files = Map.keys . Map.fromList $
+                    [ (posFile (diagPos e), ()) | e <- diags ] ++
+                    [ (posFile (spanPos s), ()) | e <- diags, s <- diagSpans e ]
         cache <- Map.fromList <$> mapM (\f -> do
             ls <- Text.lines . Text.decodeUtf8 <$> BS.readFile f
             return (f, ls)) files


### PR DESCRIPTION
Nullability linter now pinpoints specific parameter mismatches across declarations and definitions using multi-file diagnostic spans. Unannotated parameters are now treated as unspecified, allowing them to be overridden by explicit annotations without conflict.

Ownership-decls linter now uses a multi-stage collection pass to resolve function typedefs before processing usage. This enables implementation files (.c) to correctly inherit public API context from headers, avoiding redundant annotation warnings when implementing public callbacks.

Updated diagnostic reporting to correctly cache and display source context for all files involved in multi-file spans.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-tokstyle/285)
<!-- Reviewable:end -->
